### PR TITLE
fix: re-add examples folder

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# ServerlessLLM example scripts
+
+TBD


### PR DESCRIPTION
- This PR re-adds the `examples` folder.The `examples` folder is essential as the Dockerfile references it with the line `COPY examples examples`. 

- The folder includes a README file (`./examples/README.md`) that will be used to document example scripts for ServerlessLLM.
