### PR TITLE
feat: change save model path with backend name

### DIFF
--- a/serverless_llm/serve/backends/transformers_backend.py
+++ b/serverless_llm/serve/backends/transformers_backend.py
@@ -22,6 +22,7 @@ import os
 import time
 import uuid
 from typing import Any, Dict, Optional
+from pathlib import Path
 
 import ray
 import torch
@@ -70,10 +71,9 @@ class TransformersBackend(SllmBackend):
                 )
                 torch_dtype = torch.float16
             storage_path = os.getenv("STORAGE_PATH", "./models")
-            # TODO: storage_path = os.path.join(storage_path, "transformers")
-
+            model_path = Path(os.path.join(storage_path, "transformers", self.model_name)).resolve()
             self.model = load_model(
-                self.model_name,
+                str(model_path),
                 device_map=device_map,
                 torch_dtype=torch_dtype,
                 storage_path=storage_path,

--- a/serverless_llm/serve/backends/vllm_backend.py
+++ b/serverless_llm/serve/backends/vllm_backend.py
@@ -140,8 +140,7 @@ class VllmBackend(SllmBackend):
             filtered_engine_config["model"] = model
         else:
             storage_path = os.getenv("STORAGE_PATH", "./models")
-            # TODO: storage_path = os.path.join(storage_path, "vllm")
-            model_path = os.path.join(storage_path, model)
+            model_path = os.path.join(storage_path, "vllm", model)
             filtered_engine_config["model"] = model_path
             # TODO: fix the load format into serverless_llm
             filtered_engine_config["load_format"] = "sharded_state"

--- a/serverless_llm/serve/controller.py
+++ b/serverless_llm/serve/controller.py
@@ -73,11 +73,6 @@ class SllmController:
         if backend is None:
             logger.error(f"Backend not specified for model {model_name}")
             return
-        if backend != "vllm":
-            # TODO: remove after fix model path problems
-            logger.warning(
-                f"Due to format different issue, please check model path for transformer backend is different compared with using vLLM backend"
-            )
         backend_config = model_config.get("backend_config", {})
         auto_scaling_config = model_config.get("auto_scaling_config", None)
         async with self.metadata_lock:

--- a/serverless_llm/serve/model_downloader.py
+++ b/serverless_llm/serve/model_downloader.py
@@ -28,8 +28,10 @@ logger = logging.getLogger("ray")
 @ray.remote(num_cpus=1)
 def download_transformers_model(model_name: str, torch_dtype: str) -> None:
     storage_path = os.getenv("STORAGE_PATH", "./models")
-    # TODO: storage_path = os.path.join(storage_path, "transformers")
-    model_dir = os.path.join(storage_path, model_name)
+    model_dir = os.path.join(storage_path, "transformers", model_name)
+    if os.path.exists(model_dir):
+        logger.info(f"Model {model_name} already exists in {model_dir}")
+        return
 
     import torch
     from transformers import AutoModelForCausalLM
@@ -47,7 +49,12 @@ def download_transformers_model(model_name: str, torch_dtype: str) -> None:
     from serverless_llm_store import save_model
 
     logger.info(f"Saving model {model_name} to {model_dir}")
-    save_model(model, model_dir)
+    try:
+        save_model(model, model_dir)
+    except Exception as e:
+        logger.error(f"Failed to save model {model_name}: {e}")
+        shutil.rmtree(model_dir)
+        raise RuntimeError(f"Failed to save model {model_name} for transformer backend: {e}")
 
     return
 
@@ -106,18 +113,20 @@ class VllmModelDownloader:
                 torch.cuda.synchronize()
 
         storage_path = os.getenv("STORAGE_PATH", "./models")
-        # TODO: storage_path = os.path.join(storage_path, "vllm")
-        output_dir = os.path.join(storage_path, model_name)
+        model_dir = os.path.join(storage_path, "vllm", model_name)
 
         # create the output directory
-        os.makedirs(output_dir, exist_ok=True)
+        if os.path.exists(model_dir):
+            logger.info(f"Model {model_name} already exists in {model_dir}")
+            return
+        os.makedirs(model_dir, exist_ok=True)
 
         try:
             with TemporaryDirectory() as cache_dir:
                 input_dir = snapshot_download(model_name, cache_dir=cache_dir)
-                _run_writer(input_dir, output_dir)
+                _run_writer(input_dir, model_dir)
         except Exception as e:
             print(f"An error occurred while saving the model: {e}")
             # remove the output dir
-            shutil.rmtree(output_dir)
-            raise e
+            shutil.rmtree(model_dir)
+            raise RuntimeError(f"Failed to save model {model_name} for vllm backend: {e}")

--- a/serverless_llm/serve/sllm_store_manager.py
+++ b/serverless_llm/serve/sllm_store_manager.py
@@ -96,10 +96,6 @@ class SllmStoreManager:
 
             for node_id in target_nodes:
                 if backend == "transformers":
-                    # TODO: remove after fix model path problems
-                    logger.warning(
-                        f"Due to format different issue, please check model path for transformer backend is different compared with using vLLM backend"
-                    )
                     await self.download_transformers_model(
                         pretrained_model_name, node_id
                     )


### PR DESCRIPTION
# Overview
This PR implements https://github.com/ServerlessLLM/ServerlessLLM/issues/19 by adding vllm / transformers prefix in model save path
# Changes Made
+ Modifies the model save path to add backend type prefix.
+ Change the transformers backend load method. Now the transformer backend will load from absolute path in order to prevent the redundant `storage_path` made by `os.join`.
+ Explicitly converting the path to a str is to prevent the grpc proto from being unable to serialize the parameter `model_name_or_path`.
