### PR TITLE
fix(cli): display model name when deploy using config

### DIFF
--- a/serverless_llm/cli/deploy.py
+++ b/serverless_llm/cli/deploy.py
@@ -95,6 +95,7 @@ class DeployCommand:
     def run(self) -> None:
         if self.config_path:
             config_data = read_config(self.config_path)
+            self.model = config_data.get("model")
         elif self.model:
             config_data = read_config(self.default_config_path)
             config_data["model"] = self.model


### PR DESCRIPTION
This pr fix a minor bug that:

when deploy using config, sllm-cli wrongly shows "deploy none". The model could be successfully deployed.

```
➜   sllm-cli deploy --config config-opt-2.7b.json
INFO 07-30 05:58:36 deploy.py:137] Deploying model None.
INFO 07-30 05:59:41 deploy.py:148] Model registered successfully.
```