### PR TITLE
fix: vllm model downloader's GPU usage

### DIFF
--- a/serverless_llm/serve/model_downloader.py
+++ b/serverless_llm/serve/model_downloader.py
@@ -107,6 +107,9 @@ class VllmModelDownloader:
                 dtype=torch_dtype,
                 tensor_parallel_size=tensor_parallel_size,
                 distributed_executor_backend="mp",
+                num_gpu_blocks_override=1,
+                enforce_eager=True,
+                max_model_len=1,
             )
             model_executer = llm_writer.llm_engine.model_executor
             # TODO: change the `save_sharded_state` to `save_serverless_llm_state`


### PR DESCRIPTION
# Overview
As discussed in https://github.com/ServerlessLLM/ServerlessLLM/pull/27, vLLM model downloader will report error when there's other resources using the GPU. This PR could partly fix that problem by setting the GPU block number to 1.
# Changes
Add three parameters when initialize vLLM model downloader:
`num_gpu_blocks_override` to override the GPU cache block num, avoid reserve lots GPU cache which is actually not used.
`enforce_eager` to avoid capture CUDA graph (which may cost several seconds), since we will not do generate operation in save model.
`max_model_len` to avoid error that GPU cache is not able to contain the model length