### PR TITLE
fix: backend workflow changes

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -1,6 +1,12 @@
 name: Backend Tests
 
-on: [push, pull_request]
+on:
+    push:
+        paths:
+            - 'serverless_llm/serve/backends/**'
+    pull_request:
+        paths:
+            - 'serverless_llm/serve/backends/**'
 
 jobs:
     worker_tests:


### PR DESCRIPTION
# Description
This PR changes the condition to trigger the backend test workflow, and only when there's modification under `serverless_llm/serve/backends`, the workflow will be triggered.