### PR TITLE
docs: Add Activate Worker Env before Apply vLLM Patch

### DIFF
--- a/docs/stable/getting_started/installation.md
+++ b/docs/stable/getting_started/installation.md
@@ -38,5 +38,6 @@ To use vLLM with ServerlessLLM, we need to apply our patch `serverless_llm/store
 
 You may do that by running our script:
 ```bash
+conda activate sllm-worker
 ./serverless_llm/store/vllm_patch/patch.sh
 ```


### PR DESCRIPTION
## Description
Add `conda activate sllm-worker` before apply vLLM patch.

## Motivation
Avoid apply vLLM patch in wrong env.

## Type of Change
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [x] I have updated the tests (if applicable).
- [x] I have updated the documentation (if applicable).