### PR TITLE
[Fix] Fix gpu unavailable report

### DIFF
--- a/serverless_llm/store/serverless_llm_store/transformers.py
+++ b/serverless_llm/store/serverless_llm_store/transformers.py
@@ -255,7 +255,7 @@ def best_effort_load(
         logger.debug(f"device_map: {device_map}")
     # check if 'cpu' is in device_map values and raise an exception
     if "cpu" in device_map.values():
-        raise ValueError("CPU is not supported in device_map.")
+        raise ValueError("GPU Unavailable.")
     logger.debug(
         f"compute_device_placement takes {time.time() - start} seconds"
     )

--- a/serverless_llm/store/serverless_llm_store/transformers.py
+++ b/serverless_llm/store/serverless_llm_store/transformers.py
@@ -259,9 +259,9 @@ def best_effort_load(
         logger.debug(f"device_map: {device_map}")
     # check if 'cpu' is in device_map values and raise an exception
     if "cpu" in device_map.values():
-        raise ValueError("The GPUs are either unavailable or do not have enough memory, \
-                         which may be due to external tasks using them, particularly the first GPU in your cluster. \
-                         Please ensure they are available and ready for use.")
+        raise ValueError('''The GPUs are either unavailable or do not have enough memory,
+                         which may be due to external tasks using them, particularly the first GPU in your cluster.
+                         Please ensure they are available and ready for use.''')
     
     logger.debug(
         f"compute_device_placement takes {time.time() - start} seconds"

--- a/serverless_llm/store/serverless_llm_store/transformers.py
+++ b/serverless_llm/store/serverless_llm_store/transformers.py
@@ -260,7 +260,7 @@ def best_effort_load(
     # check if 'cpu' is in device_map values and raise an exception
     if "cpu" in device_map.values():
         raise ValueError('''The GPUs are either unavailable or do not have enough memory,
-                         which may be due to external tasks using them, particularly the first GPU in your cluster.
+                         which may be due to external tasks using them.
                          Please ensure they are available and ready for use.''')
     
     logger.debug(

--- a/serverless_llm/store/serverless_llm_store/transformers.py
+++ b/serverless_llm/store/serverless_llm_store/transformers.py
@@ -259,7 +259,7 @@ def best_effort_load(
         logger.debug(f"device_map: {device_map}")
     # check if 'cpu' is in device_map values and raise an exception
     if "cpu" in device_map.values():
-        raise ValueError("GPU unavailable or not enough GPU memory.")
+        raise ValueError("The GPU is either unavailable or lacks sufficient memory.")
     
     logger.debug(
         f"compute_device_placement takes {time.time() - start} seconds"

--- a/serverless_llm/store/serverless_llm_store/transformers.py
+++ b/serverless_llm/store/serverless_llm_store/transformers.py
@@ -259,7 +259,9 @@ def best_effort_load(
         logger.debug(f"device_map: {device_map}")
     # check if 'cpu' is in device_map values and raise an exception
     if "cpu" in device_map.values():
-        raise ValueError("The GPU is either unavailable or lacks sufficient memory.")
+        raise ValueError("The GPUs are either unavailable or do not have enough memory, \
+                         which may be due to external tasks using them, particularly the first GPU in your cluster. \
+                         Please ensure they are available and ready for use.")
     
     logger.debug(
         f"compute_device_placement takes {time.time() - start} seconds"

--- a/serverless_llm/store/serverless_llm_store/transformers.py
+++ b/serverless_llm/store/serverless_llm_store/transformers.py
@@ -221,14 +221,18 @@ def best_effort_load(
     device_map: DeviceMapType = "auto",
     torch_dtype: Optional[torch.dtype] = None,
     storage_path: Optional[str] = None,
-):
+):  
     client = SllmStoreClient("localhost:8073")
     ret = client.load_into_cpu(model_path)
     if not ret or ret == False:
         raise ValueError(f"Failed to load model {model_path} into CPU")
 
-    replica_uuid = _get_uuid()
+    replica_uuid = _get_uuid()   
     device_map = _transform_device_map_to_dict(device_map)
+
+    if isinstance(device_map, dict):
+        if torch.device("cpu") in device_map.values() or "cpu" in device_map.values():
+            raise ValueError("CPU is not supported in device_map.")
 
     if not storage_path:
         storage_path = os.getenv("STORAGE_PATH", "./models")
@@ -255,7 +259,8 @@ def best_effort_load(
         logger.debug(f"device_map: {device_map}")
     # check if 'cpu' is in device_map values and raise an exception
     if "cpu" in device_map.values():
-        raise ValueError("GPU Unavailable.")
+        raise ValueError("GPU unavailable or not enough GPU memory.")
+    
     logger.debug(
         f"compute_device_placement takes {time.time() - start} seconds"
     )

--- a/serverless_llm/store/serverless_llm_store/transformers.py
+++ b/serverless_llm/store/serverless_llm_store/transformers.py
@@ -259,8 +259,7 @@ def best_effort_load(
         logger.debug(f"device_map: {device_map}")
     # check if 'cpu' is in device_map values and raise an exception
     if "cpu" in device_map.values():
-        raise ValueError('''The GPUs are either unavailable or do not have enough memory,
-                         which may be due to external tasks using them.
+        raise ValueError('''The GPUs are either unavailable or do not have enough memory. 
                          Please ensure they are available and ready for use.''')
     
     logger.debug(


### PR DESCRIPTION
## Description
Fix the error report when external tasks occupy the GPUs of the worker node.

## Motivation
Previously it reported that "CPU is not supported in device_map." after computing the device map, which is confusing and not related to the cause that external tasks are using the worker node's GPUs, especially the first GPU. Now it reports "GPU unavailable or not enough GPU memory" which notifies the user that the GPU is under occupation. CPU in device_map checking is moved before the device map computation. 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [x] I have updated the tests (if applicable).
- [x] I have updated the documentation (if applicable).