### PR TITLE
[test] change the trigger of cli_test

### DIFF
--- a/.github/workflows/cli_test.yaml
+++ b/.github/workflows/cli_test.yaml
@@ -1,6 +1,12 @@
 name: CLI Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+    branches:
+      - main
+    paths:
+      - 'serverless_llm/cli/**'
 
 jobs:
     cli_tests:


### PR DESCRIPTION
## Description
Change the trigger of cli_test: now the workflow only runs when serverless_llm/cli is changed.

## Motivation
Explain why this change is needed and what problem it solves.
If it fixes an issue, link it (e.g., `close #123`).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [] I have updated the tests (if applicable).
- [] I have updated the documentation (if applicable).