### PR TITLE
FIX: outlines version

### DIFF
--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -1,3 +1,6 @@
+# ServerlessLLM does not directly depend on outlines.
+# This is to fix issue: https://github.com/dottxt-ai/outlines/issues/1198
+outlines==0.0.43
 vllm==0.5.0.post1
 accelerate==0.29.3
 grpcio==1.49.1


### PR DESCRIPTION
## Description
This PR addresses an urgent issue caused by the recent release of `outlines` v0.1.0 (see [issue #1198](https://github.com/dottxt-ai/outlines/issues/1198)).  
ServerlessLLM depends on `vllm==0.5.0.post1`, which requires `outlines>=0.0.43`. However, the release of `outlines` v0.1.0 introduced a bug that affects compatibility.  
To resolve this, we are explicitly pinning `outlines==0.0.43` in this fix.

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read and followed the [Contribution Guidelines](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md).
