### PR TITLE
build(workflows): update PyPI repository URLs and secrets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,6 +103,8 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
+          repository-url: https://pypi.org/legacy/
+          password: ${{ secrets.SLLM_PYPI }}
           skip-existing: true
 
   sllm-store:
@@ -178,4 +180,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
           packages-dir: ./sllm_store/dist/
+          repository-url: https://pypi.org/legacy/
+          password: ${{ secrets.SLLM_STORE_PYPI }}
           skip-existing: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,8 +103,8 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
-          repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://pypi.org/legacy/
+          password: ${{ secrets.SLLM_PYPI }}
           skip-existing: true
 
   sllm-store:
@@ -180,6 +180,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
           packages-dir: ./sllm_store/dist/
-          repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://pypi.org/legacy/
+          password: ${{ secrets.SLLM_STORE_PYPI }}
           skip-existing: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,8 +103,6 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
-          repository-url: https://pypi.org/legacy/
-          password: ${{ secrets.SLLM_PYPI }}
           skip-existing: true
 
   sllm-store:
@@ -180,6 +178,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
           packages-dir: ./sllm_store/dist/
-          repository-url: https://pypi.org/legacy/
-          password: ${{ secrets.SLLM_STORE_PYPI }}
           skip-existing: true


### PR DESCRIPTION
## Description
- Updated repository URL from test PyPI to the official PyPI in the GitHub Actions workflow.
- Changed secrets to use `SLLM_PYPI` and `SLLM_STORE_PYPI` for publishing packages.

## Motivation
With this pr, we will publish package to pypi officially instead of testpypi from the next release.

## Type of Change
- [x] New feature

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.