### PR TITLE
ci(workflow): add Docker build and push job to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,3 +181,52 @@ jobs:
           packages-dir: ./sllm_store/dist/
           password: ${{ secrets.SLLM_STORE_PYPI }}
           skip-existing: true
+
+  build_and_push_docker:
+    name: Build and Push Docker Images
+    runs-on: ubuntu-22.04
+    needs: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Extract tag info
+        shell: bash
+        run: |
+          echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Build and Push Head Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            serverlessllm/sllm-head:${{ env.RELEASE_TAG }}
+            serverlessllm/sllm-head:latest
+          build-args: |
+            VERSION=${{ env.RELEASE_TAG }}
+
+      - name: Build and Push Worker Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile.worker
+          push: true
+          tags: |
+            serverlessllm/sllm-worker:${{ env.RELEASE_TAG }}
+            serverlessllm/sllm-worker:latest
+          build-args: |
+            VERSION=${{ env.RELEASE_TAG }}


### PR DESCRIPTION
## Description
Adds `build_and_push_docker` job to automate building and pushing head and worker Docker images with versioned and latest tags.

## Motivation
This PR enhances the CI/CD pipeline by adding a job to automate the Docker image build and push process, ensuring that up-to-date images for both head and worker components are available on Docker Hub after each release. This reduces manual steps, improves deployment consistency, and enables easier image version management.

## Type of Change
- [x] New feature

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
