### PR TITLE
fix: correct git clone path in documentation

### DIFF
--- a/docs/stable/getting_started/docker_quickstart.md
+++ b/docs/stable/getting_started/docker_quickstart.md
@@ -24,7 +24,7 @@ We will use docker compose to simplify the setup of ServerlessLLM. The `docker-c
 If you haven't already, clone the ServerlessLLM repository:
 
 ```bash
-git clone https://github.com/serverless-llm/serverlessllm.git
+git clone https://github.com/ServerlessLLM/ServerlessLLM.git
 cd serverlessllm/examples/docker/
 ```
 

--- a/docs/stable/getting_started/installation.md
+++ b/docs/stable/getting_started/installation.md
@@ -32,7 +32,7 @@ If you plan to use vLLM with ServerlessLLM, you need to apply our patch to the v
 ## Installing from source
 To install the package from source, follow these steps:
 ```bash
-git clone https://github.com/ServerlessLLM/ServerlessLLM
+git clone https://github.com/ServerlessLLM/ServerlessLLM.git
 cd ServerlessLLM
 ```
 

--- a/docs/stable/store/installation_with_rocm.md
+++ b/docs/stable/store/installation_with_rocm.md
@@ -14,7 +14,7 @@ To build `sllm-store` from source, we suggest you using the docker and build it 
 1. Clone the repository and enter the `store` directory:
 
 ```bash
-git clone git@github.com:ServerlessLLM/ServerlessLLM.git
+git clone https://github.com/ServerlessLLM/ServerlessLLM.git
 cd ServerlessLLM/sllm_store
 ```
 

--- a/docs/stable/store/quickstart.md
+++ b/docs/stable/store/quickstart.md
@@ -33,7 +33,7 @@ pip install serverless-llm-store
 1. Clone the repository and enter the `store` directory
 
 ``` bash
-git clone git@github.com:ServerlessLLM/ServerlessLLM.git
+git clone https://github.com/ServerlessLLM/ServerlessLLM.git
 cd ServerlessLLM/sllm_store
 ```
 

--- a/sllm_store/README.md
+++ b/sllm_store/README.md
@@ -16,7 +16,7 @@ pip install serverless-llm-store
 1. Clone the repository and navigate to the `store` directory:
 
 ``` bash
-git clone git@github.com:ServerlessLLM/ServerlessLLM.git
+git clone https://github.com/ServerlessLLM/ServerlessLLM.git
 cd ServerlessLLM/sllm_store
 ```
 


### PR DESCRIPTION
## Description
Corrected the git clone command path in the documentation. Updated from:
`git clone https://github.com/serverless-llm/serverlessllm.git` (i.e., wrong) or `git clone git@github.com:ServerlessLLM/ServerlessLLM.git` (i.e., ssh) to `git clone https://github.com/ServerlessLLM/ServerlessLLM.git` (i.e., https) for consistency.

## Motivation
Ensure the git clone path is accurate and consistent across documentation.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [x] I have updated the documentation (if applicable).