### PR TITLE
fix: add control_node resource to Ray components to prevent segfault

### DIFF
--- a/sllm/serve/controller.py
+++ b/sllm/serve/controller.py
@@ -37,7 +37,6 @@ class SllmControllerException(Exception):
 logger = init_logger(__name__)
 
 
-# @ray.remote(num_cpus=1, resources={"control_node": 0.1})
 class SllmController:
     def __init__(self, config: Optional[Mapping] = None):
         self.config = config
@@ -66,7 +65,8 @@ class SllmController:
             enable_storage_aware = True
         ray_manager_cls = ray.remote(StoreManager)
         self.store_manager = ray_manager_cls.options(
-            name="store_manager"
+            name="store_manager",
+            resources={"control_node": 0.1},
         ).remote(hardware_config)
         await self.store_manager.initialize_cluster.remote()
 
@@ -77,7 +77,7 @@ class SllmController:
             ray_scheduler_cls = ray.remote(FcfsScheduler)
 
         self.scheduler = ray_scheduler_cls.options(
-            name="model_loading_scheduler"
+            name="model_loading_scheduler", resources={"control_node": 0.1}
         ).remote()
 
         self.scheduler.start.remote()


### PR DESCRIPTION
## Description

This PR adds the `control_node` resource to the Ray scheduling options for `store_manager` and `model_loading_scheduler` instances in the `SllmController`. By specifying `control_node` as a required resource, we ensure that these components are scheduled on control nodes rather than worker nodes.

## Motivation

Without this change, `store_manager` and `model_loading_scheduler` could start on worker nodes, which can lead to segmentation faults under [certain conditions](https://github.com/ServerlessLLM/ServerlessLLM/issues/92#issuecomment-2369251289). By enforcing control node scheduling, we improve the reliability of the deployment and prevent these potential crashes.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).
