### PR TITLE
[fix] remove storage path from model path in transformer backend

### DIFF
--- a/docs/stable/getting_started/docker_quickstart.md
+++ b/docs/stable/getting_started/docker_quickstart.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Docker Quickstart Guide
 
-This guide shows how to quickly set up a local ServerlessLLM cluster using Docker Compose. We will start a cluster with a head node and two worker nodes, deploy and query a model using the `sllm-cli`.
+This guide shows how to quickly set up a local ServerlessLLM cluster using Docker Compose. We will start a minimal cluster with a head node and one worker node, deploy and query a model using the `sllm-cli`.
 
 ## Pre-requisites
 
@@ -12,7 +12,7 @@ Before you begin, make sure you have the following:
 
 1. **Docker**: Installed on your system. You can download it from [here](https://docs.docker.com/get-docker/).
 2. **ServerlessLLM CLI**: Installed on your system. You can install it using `pip install serverless-llm`.
-1. **GPUs**: At least 2 NVIDIA GPUs are necessary. If you have more GPUs, you can adjust the `docker-compose.yml` file accordingly.
+1. **GPUs**: At least one NVIDIA GPU is necessary. If you have more GPUs, you can adjust the `docker-compose.yml` file accordingly.
 2. **NVIDIA Docker Toolkit**: This allows Docker to use NVIDIA GPUs. Follow the installation guide [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
 
 ## Run ServerlessLLM using Docker Compose

--- a/docs/stable/getting_started/quickstart.md
+++ b/docs/stable/getting_started/quickstart.md
@@ -19,7 +19,8 @@ ray start --head --port=6379 --num-cpus=4 --num-gpus=0 \
 In a new terminal, start the worker node:
 ```bash
 conda activate sllm-worker
-ray start --address=0.0.0.0:6379 --num-cpus=4 --num-gpus=2 \
+export CUDA_VISIBLE_DEVICES=0
+ray start --address=0.0.0.0:6379 --num-cpus=4 --num-gpus=1 \
 --resources='{"worker_node": 1, "worker_id_0": 1}' --block
 ```
 
@@ -27,22 +28,23 @@ And start ServerlessLLM Store server. This server will use `./models` as the sto
 
 ```bash
 conda activate sllm-worker
+export CUDA_VISIBLE_DEVICES=0
 sllm-store-server
 ```
 
 Expected output:
 ```bash
 $ sllm-store-server
-TODO Run server...
+Run server...
 WARNING: Logging before InitGoogleLogging() is written to STDERR
-I20240720 08:40:59.634253 141776 server.cpp:307] Log directory already exists.
-I20240720 08:40:59.671192 141776 checkpoint_store.cpp:46] Number of GPUs: 2
-I20240720 08:40:59.671768 141776 checkpoint_store.cpp:48] I/O threads: 4, chunk size: 32MB
-I20240720 08:40:59.797175 141776 checkpoint_store.cpp:69] GPU 0 UUID: cef23f2a-71f7-44f3-8246-5ebd870755e7
-I20240720 08:40:59.951408 141776 checkpoint_store.cpp:69] GPU 1 UUID: bbd10d20-aed8-4324-8b2e-7b6e54aaca0e
-I20240720 08:41:00.759124 141776 pinned_memory_pool.cpp:29] Creating PinnedMemoryPool with 1024 buffers of 33554432 bytes
-I20240720 08:41:24.315564 141776 checkpoint_store.cpp:80] Memory pool created with 32GB
-I20240720 08:41:24.318261 141776 server.cpp:279] Server listening on 0.0.0.0:8073
+I20241111 16:34:14.856642 467195 server.cpp:333] Log directory already exists.
+I20241111 16:34:14.897728 467195 checkpoint_store.cpp:41] Number of GPUs: 1
+I20241111 16:34:14.897949 467195 checkpoint_store.cpp:43] I/O threads: 4, chunk size: 32MB
+I20241111 16:34:14.897960 467195 checkpoint_store.cpp:45] Storage path: "./models/"
+I20241111 16:34:14.972811 467195 checkpoint_store.cpp:71] GPU 0 UUID: c9938b31-33b0-e02f-24c5-88bd6fbe19ad
+I20241111 16:34:14.972856 467195 pinned_memory_pool.cpp:29] Creating PinnedMemoryPool with 128 buffers of 33554432 bytes
+I20241111 16:34:16.449775 467195 checkpoint_store.cpp:83] Memory pool created with 4GB
+I20241111 16:34:16.462957 467195 server.cpp:306] Server listening on 0.0.0.0:8073
 ```
 
 Now, let’s start ServerlessLLM.
@@ -89,9 +91,3 @@ sllm-cli delete facebook/opt-1.3b
 ```
 
 This will remove the specified model from the ServerlessLLM server.
-
-You can also remove several models at once by providing multiple model names separated by spaces:
-
-```bash
-sllm-cli delete facebook/opt-1.3b facebook/opt-2.7b
-```

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -36,27 +36,27 @@ services:
     volumes:
       - ${MODEL_FOLDER}:/models
 
-  # Ray Worker Node 1
-  ray_worker_1:
-    build:
-      context: ../../
-      dockerfile: Dockerfile.worker
-    image: serverlessllm/sllm-serve-worker
-    container_name: ray_worker_1
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              capabilities: ["gpu"]
-              count: 1  # Assigns 1 GPU to the worker
-    environment:
-      - WORKER_ID=1
-      - MODEL_FOLDER=${MODEL_FOLDER}
-    networks:
-      - sllm_network
-    volumes:
-      - ${MODEL_FOLDER}:/models
+  # # Ray Worker Node 1
+  # ray_worker_1:
+  #   build:
+  #     context: ../../
+  #     dockerfile: Dockerfile.worker
+  #   image: serverlessllm/sllm-serve-worker
+  #   container_name: ray_worker_1
+  #   deploy:
+  #     resources:
+  #       reservations:
+  #         devices:
+  #           - driver: nvidia
+  #             capabilities: ["gpu"]
+  #             count: 1  # Assigns 1 GPU to the worker
+  #   environment:
+  #     - WORKER_ID=1
+  #     - MODEL_FOLDER=${MODEL_FOLDER}
+  #   networks:
+  #     - sllm_network
+  #   volumes:
+  #     - ${MODEL_FOLDER}:/models
 
 networks:
   sllm_network:

--- a/sllm/serve/backends/transformers_backend.py
+++ b/sllm/serve/backends/transformers_backend.py
@@ -20,7 +20,6 @@ import json
 import os
 import time
 import uuid
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 import torch

--- a/sllm/serve/backends/transformers_backend.py
+++ b/sllm/serve/backends/transformers_backend.py
@@ -77,11 +77,9 @@ class TransformersBackend(SllmBackend):
                 )
 
             storage_path = os.getenv("STORAGE_PATH", "./models")
-            model_path = Path(
-                os.path.join(storage_path, "transformers", self.model_name)
-            ).resolve()
+            model_path = os.path.join("transformers", self.model_name)
             self.model = load_model(
-                str(model_path),
+                model_path,
                 device_map=device_map,
                 torch_dtype=torch_dtype,
                 storage_path=storage_path,

--- a/sllm/serve/controller.py
+++ b/sllm/serve/controller.py
@@ -37,7 +37,6 @@ class SllmControllerException(Exception):
 logger = init_logger(__name__)
 
 
-# @ray.remote(num_cpus=1, resources={"control_node": 0.1})
 class SllmController:
     def __init__(self, config: Optional[Mapping] = None):
         self.config = config
@@ -66,7 +65,8 @@ class SllmController:
             enable_storage_aware = True
         ray_manager_cls = ray.remote(StoreManager)
         self.store_manager = ray_manager_cls.options(
-            name="store_manager"
+            name="store_manager",
+            resources={"control_node": 0.1},
         ).remote(hardware_config)
         await self.store_manager.initialize_cluster.remote()
 
@@ -77,7 +77,7 @@ class SllmController:
             ray_scheduler_cls = ray.remote(FcfsScheduler)
 
         self.scheduler = ray_scheduler_cls.options(
-            name="model_loading_scheduler"
+            name="model_loading_scheduler", resources={"control_node": 0.1}
         ).remote()
 
         self.scheduler.start.remote()

--- a/tests/backend_test/transformers_backend_test.py
+++ b/tests/backend_test/transformers_backend_test.py
@@ -16,7 +16,6 @@
 #  limitations under the License.                                              #
 # ---------------------------------------------------------------------------- #
 import os
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -74,18 +73,16 @@ async def test_init_backend(transformers_backend, backend_config):
         await transformers_backend.init_backend()
         mock_load_model.assert_called_once()
         storage_path = os.getenv("STORAGE_PATH", "./models")
-        model_path = Path(
-            os.path.join(
-                "transformers",
-                backend_config["pretrained_model_name_or_path"],
-            )
-        ).resolve()
+        model_path = os.path.join(
+            "transformers",
+            backend_config["pretrained_model_name_or_path"],
+        )
         device_map = backend_config.get("device_map", "auto")
         torch_dtype = backend_config.get("torch_dtype", torch.float16)
         torch_dtype = getattr(torch, torch_dtype)
         hf_model_class = backend_config.get("hf_model_class", None)
         mock_load_model.assert_called_once_with(
-            str(model_path),
+            model_path,
             device_map=device_map,
             torch_dtype=torch_dtype,
             storage_path=storage_path,
@@ -101,18 +98,16 @@ async def test_init_encoder_backend(encoder_backend, encoder_config):
         await encoder_backend.init_backend()
         mock_load_model.assert_called_once()
         storage_path = os.getenv("STORAGE_PATH", "./models")
-        model_path = Path(
-            os.path.join(
-                "transformers",
-                encoder_config["pretrained_model_name_or_path"],
-            )
-        ).resolve()
+        model_path = os.path.join(
+            "transformers",
+            encoder_config["pretrained_model_name_or_path"],
+        )
         device_map = encoder_config.get("device_map", "auto")
         torch_dtype = encoder_config.get("torch_dtype", torch.float16)
         torch_dtype = getattr(torch, torch_dtype)
         hf_model_class = encoder_config.get("hf_model_class", None)
         mock_load_model.assert_called_once_with(
-            str(model_path),
+            model_path,
             device_map=device_map,
             torch_dtype=torch_dtype,
             storage_path=storage_path,

--- a/tests/backend_test/transformers_backend_test.py
+++ b/tests/backend_test/transformers_backend_test.py
@@ -76,7 +76,6 @@ async def test_init_backend(transformers_backend, backend_config):
         storage_path = os.getenv("STORAGE_PATH", "./models")
         model_path = Path(
             os.path.join(
-                storage_path,
                 "transformers",
                 backend_config["pretrained_model_name_or_path"],
             )
@@ -104,7 +103,6 @@ async def test_init_encoder_backend(encoder_backend, encoder_config):
         storage_path = os.getenv("STORAGE_PATH", "./models")
         model_path = Path(
             os.path.join(
-                storage_path,
                 "transformers",
                 encoder_config["pretrained_model_name_or_path"],
             )


### PR DESCRIPTION
## Description
This PR removes the `storage_path` prefix from the transformers backend, aligning the format between model registration and model loading. Models are now referenced uniformly as `backend_name/model_name`.

## Motivation
This change is necessary to address inconsistencies between model registration and model loading paths. By standardizing the path format, it ensures smoother model operations and reduces the likelihood of path mismatches. 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).
