### PR TITLE
docs: update Docker to add guide for specifying GPU devices

### DIFF
--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -11,7 +11,9 @@ Note: Make sure you have Docker installed on your system and NVIDIA GPUs availab
 
 ServerlessLLM now supports flexible runtime configurations for both the head and worker nodes through customizable command-line arguments. You can adjust these settings in the `docker-compose.yml` file to optimize resource allocation and adapt the deployment to your specific needs.
 
-### Example: Adjusting Memory Pool Size
+### Examples:
+
+#### 1. Adjusting Memory Pool Size
 
 To use a memory pool size of 16GB, modify the `command` entry for each `sllm_worker_#` service in `docker-compose.yml` as follows:
 
@@ -20,3 +22,11 @@ command: ["-mem_pool_size", "16", "-registration_required", "true"]
 ```
 
 This command line option will set a memory pool size of 16GB for each worker node.
+
+#### 2. Specifying GPU Devices
+
+To specify the GPU devices to be used by the worker nodes, modify the `device_ids` entry for each `sllm_worker_#` service in `docker-compose.yml` as follows:
+
+```yaml
+device_ids: ["0", "1"]
+```

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -30,3 +30,5 @@ To specify the GPU devices to be used by the worker nodes, modify the `device_id
 ```yaml
 device_ids: ["0", "1"]
 ```
+
+This configuration will assign GPUs 0 and 1 to the worker nodes.

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
           devices:
             - driver: nvidia
               capabilities: ["gpu"]
-              device_ids: ["0, 1"] # Assigns GPU 0 to the worker
+              device_ids: ["0"] # Assigns GPU 0 to the worker
     environment:
       - WORKER_ID=0
       - STORAGE_PATH=/models

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
           devices:
             - driver: nvidia
               capabilities: ["gpu"]
-              count: 1  # Assigns 1 GPU to the worker
+              device_ids: ["0, 1"] # Assigns GPU 0 to the worker
     environment:
       - WORKER_ID=0
       - STORAGE_PATH=/models
@@ -36,22 +36,22 @@ services:
       - sllm_network
     volumes:
       - ${MODEL_FOLDER}:/models
-    command: ["-mem_pool_size", "4", "-registration_required", "true"]
+    command: ["-mem_pool_size", "4", "-registration_required", "true"] # Customize the memory pool size here
 
-  # # Ray Worker Node 1
-  # ray_worker_1:
+  # # Worker Node 1
+  # sllm_worker_1:
   #   build:
   #     context: ../../
   #     dockerfile: Dockerfile.worker
   #   image: serverlessllm/sllm-serve-worker
-  #   container_name: ray_worker_1
+  #   container_name: sllm_worker_1
   #   deploy:
   #     resources:
   #       reservations:
   #         devices:
   #           - driver: nvidia
   #             capabilities: ["gpu"]
-  #             count: 1  # Assigns 1 GPU to the worker
+  #             device_ids: ["1"] # Assigns GPU 1 to the worker
   #   environment:
   #     - WORKER_ID=1
   #     - MODEL_FOLDER=${MODEL_FOLDER}
@@ -59,7 +59,7 @@ services:
   #     - sllm_network
   #   volumes:
   #     - ${MODEL_FOLDER}:/models
-  #   command: ["-mem_pool_size", "4", "-registration_required", "true"]
+  #   command: ["-mem_pool_size", "4", "-registration_required", "true"] # Customize the memory pool size here
 
 networks:
   sllm_network:


### PR DESCRIPTION
## Description
Update docker example, add guidance for specifying GPU devices that worker nodes run on.

## Motivation
Now the docker compose config doesn't support specifying GPU devices to run on for worker nodes.

## Type of Change
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.