### PR TITLE
docs: correct directory name in Docker quickstart documentation

### DIFF
--- a/docs/stable/getting_started/docker_quickstart.md
+++ b/docs/stable/getting_started/docker_quickstart.md
@@ -25,7 +25,7 @@ If you haven't already, clone the ServerlessLLM repository:
 
 ```bash
 git clone https://github.com/ServerlessLLM/ServerlessLLM.git
-cd serverlessllm/examples/docker/
+cd ServerlessLLM/examples/docker/
 ```
 
 ### Step 2:  Configuration


### PR DESCRIPTION
## Description
Correct directory name in Docker quickstart documentation:
Standardize to "ServerlessLLM" for consistency across the project.

## Type of Change
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.