### PR TITLE
fix: Fix dtype error for vllm downloader

### DIFF
--- a/sllm/serve/store_manager.py
+++ b/sllm/serve/store_manager.py
@@ -389,7 +389,7 @@ class StoreManager:
                         node_id,
                         model_config.get("num_gpus", 1),
                         backend_config.get("tensor_parallel_size", 1),
-                        torch_dtype.get("torch_dtype", "float16"),
+                        backend_config.get("torch_dtype", "float16"),
                     )
                 else:
                     logger.error(f"Backend {backend} not supported")

--- a/sllm/serve/store_manager.py
+++ b/sllm/serve/store_manager.py
@@ -389,7 +389,7 @@ class StoreManager:
                         node_id,
                         model_config.get("num_gpus", 1),
                         backend_config.get("tensor_parallel_size", 1),
-                        torch_dtype,
+                        torch_dtype.get("torch_dtype", "float16"),
                     )
                 else:
                     logger.error(f"Backend {backend} not supported")


### PR DESCRIPTION
## Description
The dtype of vllm downloader was not assigned correctly, which will cause error when downloading models using vllm backend.

## Motivation
Fix this issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).