### PR TITLE
feat: add keep_alive config

### DIFF
--- a/sllm/cli/default_config.json
+++ b/sllm/cli/default_config.json
@@ -6,7 +6,8 @@
         "metric": "concurrency",
         "target": 1,
         "min_instances": 0,
-        "max_instances": 10
+        "max_instances": 10,
+        "keep_alive": 10
     },
     "backend_config": {
         "pretrained_model_name_or_path": "",

--- a/sllm/cli/default_config.json
+++ b/sllm/cli/default_config.json
@@ -7,7 +7,7 @@
         "target": 1,
         "min_instances": 0,
         "max_instances": 10,
-        "keep_alive": 10
+        "keep_alive": 0
     },
     "backend_config": {
         "pretrained_model_name_or_path": "",

--- a/sllm/serve/routers/roundrobin_router.py
+++ b/sllm/serve/routers/roundrobin_router.py
@@ -221,7 +221,7 @@ class RoundRobinRouter(SllmRouter):
                 logger.info("Creating new instance")
                 await self._create_instance()
             elif desired_instances < num_running_instances:
-                keep_alive = auto_scaling_config["keep_alive"]
+                keep_alive = auto_scaling_config.get("keep_alive", -1)
                 if self.idle_time > keep_alive:
                     logger.info(
                         f"Stopping instance, idle_time: {self.idle_time}, keep_alive: {keep_alive}"

--- a/sllm/serve/routers/roundrobin_router.py
+++ b/sllm/serve/routers/roundrobin_router.py
@@ -221,8 +221,8 @@ class RoundRobinRouter(SllmRouter):
                 logger.info("Creating new instance")
                 await self._create_instance()
             elif desired_instances < num_running_instances:
-                keep_alive = auto_scaling_config.get("keep_alive", -1)
-                if self.idle_time > keep_alive:
+                keep_alive = auto_scaling_config.get("keep_alive", 0)
+                if self.idle_time >= keep_alive:
                     logger.info(
                         f"Stopping instance, idle_time: {self.idle_time}, keep_alive: {keep_alive}"
                     )


### PR DESCRIPTION
## Description
Add `keep_alive` field in `auto_scaling_config` to let model last for a while after the request is finished.

## Motivation
As it mentioned in #159 , sometimes we want model do not offload immediately when it finished a request, because there may be another request coming soon. `keep_alive` config aims to resolve the problem.
close #159 .

For example, the config below will let model last for 30 seconds after it finished a request, if there is still no new request, then offload.
```json
{
    "model": "",
    "backend": "vllm",
    "num_gpus": 1,
    "auto_scaling_config": {
        "metric": "concurrency",
        "target": 1,
        "min_instances": 0,
        "max_instances": 10,
        "keep_alive": 30
    },
    "backend_config": {
        "pretrained_model_name_or_path": "",
        "device_map": "auto",
        "torch_dtype": "float16",
        "hf_model_class": "AutoModelForCausalLM"
    }
}
```


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).