### PR TITLE
release: boost version to 0.5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ sys.path.append(Path.cwd().as_posix())
 
 setup(
     name="serverless-llm",
-    version="0.5.1",
+    version="0.5.2",
     install_requires=install_requires,
     long_description=read_readme(),
     long_description_content_type="text/markdown",

--- a/sllm_store/setup.py
+++ b/sllm_store/setup.py
@@ -273,7 +273,7 @@ cmdclass = {
 
 setup(
     name="serverless-llm-store",
-    version="0.5.1",
+    version="0.5.2",
     ext_modules=[
         CMakeExtension(name="sllm_store._C"),
         CMakeExtension(name="sllm_store.sllm_store_server"),


### PR DESCRIPTION
## Description
This PR updates the version number to **0.5.2**.

## Motivation
The goal is to release recent fixes before introducing the live-migration feature.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).