### PR TITLE
feat: support local model path

### DIFF
--- a/docs/stable/cli/cli_api.md
+++ b/docs/stable/cli/cli_api.md
@@ -126,7 +126,7 @@ Below is a description of all the fields in config.json.
 | backend | Inference engine, support `transformers` and `vllm` now. |
 | num_gpus | Number of GPUs used to deploy a model instance. |
 | auto_scaling_config | Config about auto scaling. |
-| auto_scaling_config.metric | Metic used to decide whether to scale up or down. |
+| auto_scaling_config.metric | Metric used to decide whether to scale up or down. |
 | auto_scaling_config.target | Target value of the metric. |
 | auto_scaling_config.min_instances | The minimum value for model instances. |
 | auto_scaling_config.max_instances | The maximum value for model instances. |

--- a/docs/stable/cli/cli_api.md
+++ b/docs/stable/cli/cli_api.md
@@ -106,15 +106,36 @@ This file can be incomplete, and missing sections will be filled in by the defau
         "metric": "concurrency",
         "target": 1,
         "min_instances": 0,
-        "max_instances": 10
+        "max_instances": 10,
+        "keep_alive": 0
     },
     "backend_config": {
         "pretrained_model_name_or_path": "facebook/opt-1.3b",
         "device_map": "auto",
-        "torch_dtype": "float16"
+        "torch_dtype": "float16",
+        "hf_model_class": "AutoModelForCausalLM"
     }
 }
 ```
+
+Below is a description of all the fields in config.json.
+
+| Field | Description |
+| ----- | ----------- |
+| model | This should be a HuggingFace model name, used to identify model instance. |
+| backend | Inference engine, support `transformers` and `vllm` now. |
+| num_gpus | Number of GPUs used to deploy a model instance. |
+| auto_scaling_config | Config about auto scaling. |
+| auto_scaling_config.metric | Metic used to decide whether to scale up or down. |
+| auto_scaling_config.target | Target value of the metric. |
+| auto_scaling_config.min_instances | The minimum value for model instances. |
+| auto_scaling_config.max_instances | The maximum value for model instances. |
+| auto_scaling_config.keep_alive | How long a model instance lasts after inference ends. For example, if keep_alive is set to 30, it will wait 30 seconds after the inference ends to see if there is another request. |
+| backend_config | Config about inference backend. |
+| backend_config.pretrained_model_name_or_path | The path to load the model, this can be a HuggingFace model name or a local path. |
+| backend_config.device_map | Device map config used to load the model, `auto` is suitable for most scenarios. |
+| backend_config.torch_dtype | Torch dtype of the model. |
+| backend_config.hf_model_class | HuggingFace model class. |
 
 ### sllm-cli delete
 Delete deployed models by name.

--- a/docs/stable/getting_started/quickstart.md
+++ b/docs/stable/getting_started/quickstart.md
@@ -67,6 +67,8 @@ conda activate sllm
 sllm-cli deploy --model facebook/opt-1.3b
 ```
 
+This will download the model from HuggingFace, if you want load the model from local path, you can use `config.json`, see [here](../cli/cli_api.md#example-configuration-file-configjson) for details.
+
 Now, you can query the model by any OpenAI API client. For example, you can use the following Python code to query the model:
 ```bash
 curl http://127.0.0.1:8343/v1/chat/completions \

--- a/sllm/serve/backends/backend_utils.py
+++ b/sllm/serve/backends/backend_utils.py
@@ -29,7 +29,9 @@ class BackendStatus(Enum):
 
 class SllmBackend(ABC):
     @abstractmethod
-    def __init__(self, backend_config: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self, model_name: str, backend_config: Optional[Dict[str, Any]] = None
+    ) -> None:
         pass
 
     @abstractmethod

--- a/sllm/serve/backends/transformers_backend.py
+++ b/sllm/serve/backends/transformers_backend.py
@@ -78,7 +78,6 @@ class TransformersBackend(SllmBackend):
         self.status: BackendStatus = BackendStatus.UNINITIALIZED
         self.inf_status = InferenceStatus(self.status)
         self.status_lock = threading.Lock()
-        self.model_name = backend_config.get("pretrained_model_name_or_path")
         self.model = None
         self.tokenizer = None
         self.past_key_values = None

--- a/sllm/serve/backends/transformers_backend.py
+++ b/sllm/serve/backends/transformers_backend.py
@@ -64,10 +64,16 @@ class InferenceStatus(BaseStreamer):
 
 
 class TransformersBackend(SllmBackend):
-    def __init__(self, backend_config: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self, model_name: str, backend_config: Optional[Dict[str, Any]] = None
+    ) -> None:
         self.backend_config = backend_config
         logger.info(
-            f"Initializing TransformersBackend with config: {backend_config}"
+            f"Initializing TransformersBackend for {model_name} with config: {backend_config}"
+        )
+        self.model_name = model_name
+        self.pretrained_model_name_or_path = backend_config.get(
+            "pretrained_model_name_or_path"
         )
         self.status: BackendStatus = BackendStatus.UNINITIALIZED
         self.inf_status = InferenceStatus(self.status)
@@ -116,7 +122,9 @@ class TransformersBackend(SllmBackend):
                 storage_path=storage_path,
                 hf_model_class=hf_model_class,
             )
-            self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                self.pretrained_model_name_or_path
+            )
             self.status = BackendStatus.RUNNING
 
     def _tokenize(self, prompt: str):

--- a/sllm/serve/backends/vllm_backend.py
+++ b/sllm/serve/backends/vllm_backend.py
@@ -109,7 +109,9 @@ class VllmBackend(SllmBackend):
     # - stop: stops every ongoing request and then stops the backend
     # - get_current_tokens: returns a list of all ongoing request tokens
     # - resume_kv_cache: resumes the key-value cache for the given requests
-    def __init__(self, backend_config: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self, model: str, backend_config: Optional[Dict[str, Any]] = None
+    ) -> None:
         if backend_config is None:
             raise ValueError("Backend config is missing")
 
@@ -124,9 +126,6 @@ class VllmBackend(SllmBackend):
         filtered_engine_config = {
             k: v for k, v in backend_config.items() if k in async_engine_fields
         }
-        # warp to set model name
-        # TODO: Change the format of model from 'pretrained_model_name_or_path' to 'model'
-        model = backend_config.get("pretrained_model_name_or_path")
 
         load_format = backend_config.get("load_format")
         torch_dtype = backend_config.get("torch_dtype")
@@ -135,7 +134,9 @@ class VllmBackend(SllmBackend):
 
         if load_format is not None:
             filtered_engine_config["load_format"] = load_format
-            filtered_engine_config["model"] = model
+            filtered_engine_config["model"] = backend_config.get(
+                "pretrained_model_name_or_path"
+            )
         else:
             storage_path = os.getenv("STORAGE_PATH", "./models")
             model_path = os.path.join(storage_path, "vllm", model)

--- a/sllm/serve/inference_instance.py
+++ b/sllm/serve/inference_instance.py
@@ -24,7 +24,9 @@ logger = init_logger(__name__)
 
 
 @ray.remote
-def start_instance(instance_id, backend, backend_config, startup_config):
+def start_instance(
+    instance_id, backend, model_name, backend_config, startup_config
+):
     logger.info(f"Starting instance {instance_id} with backend {backend}")
     if backend == "vllm":
         from sllm.serve.backends import VllmBackend
@@ -43,5 +45,5 @@ def start_instance(instance_id, backend, backend_config, startup_config):
         raise ValueError(f"Unknown backend: {backend}")
 
     return model_backend_cls.options(name=instance_id, **startup_config).remote(
-        backend_config
+        model_name, backend_config
     )

--- a/sllm/serve/model_downloader.py
+++ b/sllm/serve/model_downloader.py
@@ -38,7 +38,10 @@ logger = logging.getLogger("ray")
 
 @ray.remote(num_cpus=1)
 def download_transformers_model(
-    model_name: str, torch_dtype: str, hf_model_class: str
+    model_name: str,
+    pretrained_model_name_or_path: str,
+    torch_dtype: str,
+    hf_model_class: str,
 ) -> bool:
     storage_path = os.getenv("STORAGE_PATH", "./models")
     model_path = os.path.join(storage_path, "transformers", model_name)
@@ -58,7 +61,9 @@ def download_transformers_model(
     module = importlib.import_module("transformers")
     hf_model_cls = getattr(module, hf_model_class)
     model = hf_model_cls.from_pretrained(
-        model_name, torch_dtype=torch_dtype, trust_remote_code=True
+        pretrained_model_name_or_path,
+        torch_dtype=torch_dtype,
+        trust_remote_code=True,
     )
 
     from sllm_store.transformers import save_model
@@ -86,6 +91,7 @@ class VllmModelDownloader:
     def download_vllm_model(
         self,
         model_name: str,
+        pretrained_model_name_or_path: str,
         torch_dtype: str,
         tensor_parallel_size: int = 1,
         pattern: Optional[str] = None,
@@ -106,55 +112,59 @@ class VllmModelDownloader:
             return
 
         try:
-            with TemporaryDirectory() as cache_dir:
-                # download from huggingface
-                input_dir = snapshot_download(
-                    model_name,
-                    cache_dir=cache_dir,
-                    allow_patterns=[
-                        "*.safetensors",
-                        "*.bin",
-                        "*.json",
-                        "*.txt",
-                    ],
-                )
-                logger.info(input_dir)
-                # load models from the input directory
-                llm_writer = LLM(
-                    model=input_dir,
-                    download_dir=input_dir,
-                    dtype=torch_dtype,
-                    tensor_parallel_size=tensor_parallel_size,
-                    num_gpu_blocks_override=1,
-                    enforce_eager=True,
-                    max_model_len=1,
-                )
-                model_executer = llm_writer.llm_engine.model_executor
-                # save the models in the ServerlessLLM format
-                model_executer.save_serverless_llm_state(
-                    path=model_path, pattern=pattern, max_size=max_size
-                )
-                for file in os.listdir(input_dir):
-                    # Copy the metadata files into the output directory
-                    if os.path.splitext(file)[1] not in (
-                        ".bin",
-                        ".pt",
-                        ".safetensors",
-                    ):
-                        src_path = os.path.join(input_dir, file)
-                        dest_path = os.path.join(model_path, file)
-                        logger.info(src_path)
-                        logger.info(dest_path)
-                        if os.path.isdir(src_path):
-                            shutil.copytree(src_path, dest_path)
-                        else:
-                            shutil.copy(src_path, dest_path)
-                del model_executer
-                del llm_writer
-                gc.collect()
-                if torch.cuda.is_available():
-                    torch.cuda.empty_cache()
-                    torch.cuda.synchronize()
+            if os.path.exists(pretrained_model_name_or_path):
+                input_dir = pretrained_model_name_or_path
+            else:
+                with TemporaryDirectory() as cache_dir:
+                    # download from huggingface
+                    input_dir = snapshot_download(
+                        model_name,
+                        cache_dir=cache_dir,
+                        allow_patterns=[
+                            "*.safetensors",
+                            "*.bin",
+                            "*.json",
+                            "*.txt",
+                        ],
+                    )
+            logger.info(input_dir)
+
+            # load models from the input directory
+            llm_writer = LLM(
+                model=input_dir,
+                download_dir=input_dir,
+                dtype=torch_dtype,
+                tensor_parallel_size=tensor_parallel_size,
+                num_gpu_blocks_override=1,
+                enforce_eager=True,
+                max_model_len=1,
+            )
+            model_executer = llm_writer.llm_engine.model_executor
+            # save the models in the ServerlessLLM format
+            model_executer.save_serverless_llm_state(
+                path=model_path, pattern=pattern, max_size=max_size
+            )
+            for file in os.listdir(input_dir):
+                # Copy the metadata files into the output directory
+                if os.path.splitext(file)[1] not in (
+                    ".bin",
+                    ".pt",
+                    ".safetensors",
+                ):
+                    src_path = os.path.join(input_dir, file)
+                    dest_path = os.path.join(model_path, file)
+                    logger.info(src_path)
+                    logger.info(dest_path)
+                    if os.path.isdir(src_path):
+                        shutil.copytree(src_path, dest_path)
+                    else:
+                        shutil.copy(src_path, dest_path)
+            del model_executer
+            del llm_writer
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+                torch.cuda.synchronize()
         except Exception as e:
             print(f"An error occurred while saving the model: {e}")
             # remove the output dir

--- a/sllm/serve/routers/roundrobin_router.py
+++ b/sllm/serve/routers/roundrobin_router.py
@@ -283,7 +283,13 @@ class RoundRobinRouter(SllmRouter):
                 "worker_node": 0.1,
                 f"worker_id_{startup_node}": 0.1,
             }
-        ).remote(instance_id, self.backend, self.backend_config, startup_config)
+        ).remote(
+            instance_id,
+            self.backend,
+            self.model_name,
+            self.backend_config,
+            startup_config,
+        )
         logger.info(
             f"Started instance {instance_id} for model {self.model_name}"
         )

--- a/sllm/serve/store_manager.py
+++ b/sllm/serve/store_manager.py
@@ -360,8 +360,7 @@ class StoreManager:
             logger.info(f"Registering new {model_name}")
 
             backend = model_config.get("backend", None)
-
-            pretrained_model_name = backend_config.get(
+            pretrained_model_name_or_path = backend_config.get(
                 "pretrained_model_name_or_path", None
             )
             # 1. download this model to one worker using round-robin
@@ -396,7 +395,7 @@ class StoreManager:
                 target_nodes = [node_id]
 
             logger.info(
-                f"Downloading model {pretrained_model_name} to nodes {target_nodes}"  # noqa: E501
+                f"Downloading model {pretrained_model_name_or_path} to nodes {target_nodes}"  # noqa: E501
             )
             for node_id in target_nodes:
                 if backend == "transformers":
@@ -408,14 +407,16 @@ class StoreManager:
                         )
                         break
                     await self.download_transformers_model(
-                        pretrained_model_name,
+                        model_name,
+                        pretrained_model_name_or_path,
                         node_id,
                         hf_model_class,
                         torch_dtype,
                     )
                 elif backend == "vllm":
                     await self.download_vllm_model(
-                        pretrained_model_name,
+                        model_name,
+                        pretrained_model_name_or_path,
                         node_id,
                         model_config.get("num_gpus", 1),
                         backend_config.get("tensor_parallel_size", 1),
@@ -438,22 +439,37 @@ class StoreManager:
             pass
 
     async def download_transformers_model(
-        self, pretrained_model_name, node_id, hf_model_class, torch_dtype
+        self,
+        model_name,
+        pretrained_model_name_or_path,
+        node_id,
+        hf_model_class,
+        torch_dtype,
     ) -> int:
-        logger.info(f"Downloading {pretrained_model_name} to node {node_id}")
+        logger.info(
+            f"Downloading {pretrained_model_name_or_path} to node {node_id}"
+        )
         return await download_transformers_model.options(
             resources={"worker_node": 0.1, f"worker_id_{node_id}": 0.1}
-        ).remote(pretrained_model_name, torch_dtype, hf_model_class)
+        ).remote(
+            model_name,
+            pretrained_model_name_or_path,
+            torch_dtype,
+            hf_model_class,
+        )
 
     async def download_vllm_model(
         self,
-        pretrained_model_name,
+        model_name,
+        pretrained_model_name_or_path,
         node_id,
         num_gpus,
         tensor_parallel_size,
         torch_dtype,
     ):
-        logger.info(f"Downloading {pretrained_model_name} to node {node_id}")
+        logger.info(
+            f"Downloading {pretrained_model_name_or_path} to node {node_id}"
+        )
         vllm_backend_downloader = (
             ray.remote(VllmModelDownloader)
             .options(
@@ -463,7 +479,8 @@ class StoreManager:
             .remote()
         )
         return await vllm_backend_downloader.download_vllm_model.remote(
-            pretrained_model_name,
+            model_name,
+            pretrained_model_name_or_path,
             torch_dtype,
             tensor_parallel_size,
         )

--- a/tests/backend_test/transformers_backend_test.py
+++ b/tests/backend_test/transformers_backend_test.py
@@ -73,7 +73,7 @@ def test_init(transformers_backend, model_name, backend_config):
 
 
 def test_init_encoder(encoder_backend, encoder_model_name, encoder_config):
-    assert encoder_backend.encoder_model_name == encoder_model_name
+    assert encoder_backend.model_name == encoder_model_name
     assert encoder_backend.backend_config == encoder_config
     assert encoder_backend.status == BackendStatus.UNINITIALIZED
 

--- a/tests/backend_test/transformers_backend_test.py
+++ b/tests/backend_test/transformers_backend_test.py
@@ -29,6 +29,16 @@ from sllm.serve.backends.transformers_backend import (
 
 
 @pytest.fixture
+def model_name():
+    return "facebook/opt-125m"
+
+
+@pytest.fixture
+def encoder_model_name():
+    return "BAAI/bge-small-en-v1.5"
+
+
+@pytest.fixture
 def backend_config():
     return {
         "pretrained_model_name_or_path": "facebook/opt-125m",
@@ -47,21 +57,23 @@ def encoder_config():
 
 
 @pytest.fixture
-def transformers_backend(backend_config):
-    yield TransformersBackend(backend_config)
+def transformers_backend(model_name, backend_config):
+    yield TransformersBackend(model_name, backend_config)
 
 
 @pytest.fixture
-def encoder_backend(encoder_config):
-    yield TransformersBackend(encoder_config)
+def encoder_backend(encoder_model_name, encoder_config):
+    yield TransformersBackend(encoder_model_name, encoder_config)
 
 
-def test_init(transformers_backend, backend_config):
+def test_init(transformers_backend, model_name, backend_config):
+    assert transformers_backend.model_name == model_name
     assert transformers_backend.backend_config == backend_config
     assert transformers_backend.status == BackendStatus.UNINITIALIZED
 
 
-def test_init_encoder(encoder_backend, encoder_config):
+def test_init_encoder(encoder_backend, encoder_model_name, encoder_config):
+    assert encoder_backend.encoder_model_name == encoder_model_name
     assert encoder_backend.backend_config == encoder_config
     assert encoder_backend.status == BackendStatus.UNINITIALIZED
 

--- a/tests/backend_test/vllm_backend_test.py
+++ b/tests/backend_test/vllm_backend_test.py
@@ -29,6 +29,11 @@ from sllm.serve.backends.vllm_backend import (
 
 
 @pytest.fixture
+def model_name():
+    return "test-model"
+
+
+@pytest.fixture
 def backend_config():
     return {
         "pretrained_model_name_or_path": "test-model",
@@ -87,8 +92,8 @@ def async_llm_engine():
 
 
 @pytest.fixture
-def vllm_backend(backend_config, async_llm_engine):
-    yield VllmBackend(backend_config)
+def vllm_backend(model_name, backend_config, async_llm_engine):
+    yield VllmBackend(model_name, backend_config)
 
 
 def test_init(vllm_backend, backend_config):
@@ -140,10 +145,10 @@ async def test_generate(vllm_backend, async_llm_engine):
 
 
 @pytest.mark.asyncio
-async def test_shutdown(backend_config, async_llm_engine):
+async def test_shutdown(model_name, backend_config, async_llm_engine):
     # Open trace debug to avoid clean the finished request in record map
     backend_config["trace_debug"] = True
-    vllm_backend = VllmBackend(backend_config)
+    vllm_backend = VllmBackend(model_name, backend_config)
     request_data = {
         "model_name": "test-model",
         "prompt": "user: Hello",
@@ -187,10 +192,10 @@ async def test_stop(vllm_backend, async_llm_engine):
 
 
 @pytest.mark.asyncio
-async def test_get_current_tokens(backend_config, async_llm_engine):
+async def test_get_current_tokens(model_name, backend_config, async_llm_engine):
     # Open trace debug to avoid clean the finished request in record map
     backend_config["trace_debug"] = True
-    vllm_backend = VllmBackend(backend_config)
+    vllm_backend = VllmBackend(model_name, backend_config)
     request_data = [
         {
             "model_name": "test-model",


### PR DESCRIPTION
## Description
Supports configuration of the local model path to omit downloading.

## Motivation
close #128.
Sometimes there is already a local model, or a network problem connecting to HuggingFace, so we want to use local model instead. 
Now we can achieve this by configuring `backend_config.pretrained_model_name_or_path`, it both supports transformers and vllm backends, for example:

```json
{
    "model": "facebook/opt-1.3b",
    "backend": "transformers",
    "num_gpus": 1,
    "auto_scaling_config": {
        "metric": "concurrency",
        "target": 1,
        "min_instances": 0,
        "max_instances": 10
    },
    "backend_config": {
        "pretrained_model_name_or_path": "/root/users/dblate/facebook/opt-1.3b",
        "device_map": "auto",
        "torch_dtype": "float16"
    }
}
```

Since the pull request contains many file changes, I'd like to state my points:
- In config, `model` and `pretrained_model_name_or_path` should be two independent fields
    - `model` used to be an identifier, like as internal keys for routers or serverless format file path
    - `pretrained_model_name_or_path` used to get the model, it can be a HuggingFace model name, or local path
- They can be the same sometimes, but not always

Feel free to modify my code or reject it if necessary. 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [x] I have updated the tests (if applicable).
- [x] I have updated the documentation (if applicable).