### PR TITLE
Free up disk space in github runner and fix build type to ubuntu20.04

### DIFF
--- a/.github/workflows/cli_test.yaml
+++ b/.github/workflows/cli_test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     cli_tests:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-20.04
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/pre-commit-format.yml
+++ b/.github/workflows/pre-commit-format.yml
@@ -18,7 +18,7 @@ jobs:
 
   # formatting and basic install on cpu-only machine
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          os: ['ubuntu-22.04']
+          os: ['ubuntu-20.04']
           python-version: ['3.10']
           pytorch-version: ['2.3.0']  # Must be the most recent version that meets requirements-cuda.txt.
           cuda-version: ['12.3']
@@ -184,11 +184,24 @@ jobs:
 
   build_and_push_docker:
     name: Build and Push Docker Images
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs: release
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Free Up GitHub Actions Ubuntu Runner Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
+          tool-cache: false
+          # All of these default to true, but feel free to set to "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+        
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -202,7 +202,6 @@ jobs:
           large-packages: true
           swap-storage: true
         
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -159,7 +159,6 @@ jobs:
           echo "wheel_name=${wheel_name}" >> $GITHUB_ENV
           echo "asset_name=${asset_name}" >> $GITHUB_ENV
 
-
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
@@ -194,7 +193,7 @@ jobs:
         shell: bash
         run: |
           bash -x .github/workflows/scripts/free-disk-space.sh
-        
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -191,16 +191,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Free Up GitHub Actions Ubuntu Runner Disk Space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
-          tool-cache: false
-          # All of these default to true, but feel free to set to "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+        shell: bash
+        run: |
+          bash -x .github/workflows/scripts/free-disk-space.sh
         
       - name: Log in to Docker Hub
         uses: docker/login-action@v2


### PR DESCRIPTION
## Description
* Change the ubuntu version in building sllm-store to 20.04(Previous commit only change the ubuntu version of sllm)
* Add a step to free up github runner space before running docker build and push

## Motivation
Fix the bug of workflow cannot build docker image and sllm-store cannot be run on ubuntu20.04

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [x] I have updated the tests (if applicable).
- [x] I have updated the documentation (if applicable).