### PR TITLE
update router & scheduler

### DIFF
--- a/sllm/serve/routers/roundrobin_router.py
+++ b/sllm/serve/routers/roundrobin_router.py
@@ -304,11 +304,12 @@ class RoundRobinRouter(SllmRouter):
         return instance_id
 
     async def _stop_instance(self, instance_id: Optional[str] = None):
-        
         # check if the instance has not started
-        while len(self.ready_instances) == 0 and len(self.starting_instances) > 0:
+        while (
+            len(self.ready_instances) == 0 and len(self.starting_instances) > 0
+        ):
             await asyncio.sleep(1)
-        
+
         async with self.instance_management_lock:
             if instance_id is None:
                 instance_id, instance = self.ready_instances.popitem()
@@ -329,10 +330,12 @@ class RoundRobinRouter(SllmRouter):
                 logger.error(f"Instance {instance_id} not found")
                 return
             instance = self.deleting_instances.pop(instance_id)
-        
+
         # ensure there's no requests being processed
         while instance.queue_length > 0:
-            logger.info(f"going to wait, queue length is {instance.queue_length}")
+            logger.info(
+                f"going to wait, queue length is {instance.queue_length}"
+            )
             await asyncio.sleep(1)
         async with instance.lock:
             instance.status = False

--- a/sllm/serve/schedulers/fcfs_scheduler.py
+++ b/sllm/serve/schedulers/fcfs_scheduler.py
@@ -94,7 +94,7 @@ class FcfsScheduler(SllmScheduler):
         logger.info("Starting control loop")
         loading_requests = []
         try:
-            # first work on earlier requests left in the previou queue
+            # first work on earlier requests left in the previous queue
             # after loading_requests becomes empty, get new requests
             while self.running:
                 if len(loading_requests) == 0:

--- a/sllm/serve/schedulers/fcfs_scheduler.py
+++ b/sllm/serve/schedulers/fcfs_scheduler.py
@@ -92,57 +92,75 @@ class FcfsScheduler(SllmScheduler):
 
     async def _control_loop(self):
         logger.info("Starting control loop")
-        while self.running:
-            loading_requests = []
-            async with self.queue_lock:
-                for (
-                    model_name,
-                    loading_queue,
-                ) in self.model_loading_queues.items():
-                    for idx, (
-                        request_time,
-                        num_gpus,
-                        allocation_result,
-                    ) in enumerate(loading_queue):
-                        loading_requests.append(
-                            (
-                                model_name,
-                                idx,
+        loading_requests = []
+        try:
+            # first work on earlier requests left in the previou queue
+            # after loading_requests becomes empty, get new requests
+            while self.running:
+                if len(loading_requests) == 0:
+                    async with self.queue_lock:
+                        for (
+                            model_name,
+                            loading_queue,
+                        ) in self.model_loading_queues.items():
+                            for idx, (
                                 request_time,
                                 num_gpus,
                                 allocation_result,
-                            )
-                        )
-            # logger.info(f"Loading requests: {loading_requests}")
-            # first come first serve
-            if len(loading_requests) > 0:
-                worker_nodes = await self._get_worker_nodes()
-                logger.info(f"Worker nodes: {worker_nodes}")
-                loading_requests.sort(key=lambda x: x[1])
-                for (
-                    model_name,
-                    idx,
-                    request_time,
-                    num_gpus,
-                    allocation_result,
-                ) in loading_requests:
-                    allocated = False
-                    for node_id, node_info in worker_nodes.items():
-                        if node_info["free_gpu"] >= num_gpus:
-                            async with self.queue_lock:
-                                self.model_loading_queues[model_name].pop(idx)
-                                allocation_result.set_result(node_id)
-                            allocated = True
-                            logger.info(
-                                f"Allocated node {node_id} for model {model_name}"
-                            )
-                            node_info["free_gpu"] -= num_gpus
-                            break
-                    if not allocated:
-                        logger.info(f"No available node for model {model_name}")
-                await self._update_worker_nodes(worker_nodes)
-
-            await asyncio.sleep(1)
+                            ) in enumerate(loading_queue):
+                                loading_requests.append(
+                                    (
+                                        model_name,
+                                        idx,
+                                        request_time,
+                                        num_gpus,
+                                        allocation_result,
+                                    )
+                                )
+                    loading_requests.sort(key= lambda x: x[1])
+                # logger.info(f"Loading requests: {loading_requests}")
+                # first come first serve
+                else:
+                    worker_nodes = await self._get_worker_nodes()
+                    logger.info(f"Worker nodes: {worker_nodes}")
+                    # loading_requests.sort(key=lambda x: x[1])
+                    for (
+                        model_name,
+                        idx,
+                        request_time,
+                        num_gpus,
+                        allocation_result,
+                    ) in loading_requests:
+                        allocated = False
+                        keep_going = False
+                        for node_id, node_info in worker_nodes.items():
+                            if node_info["free_gpu"] >= float(num_gpus):
+                                if allocation_result.done():
+                                    keep_going = True
+                                    break
+                                try:
+                                    self.model_loading_queues[model_name].remove((request_time, num_gpus, allocation_result))
+                                except ValueError: 
+                                    keep_going = True
+                                    break
+                                async with self.queue_lock:                              
+                                    allocation_result.set_result(node_id)
+                                allocated = True
+                                logger.info(
+                                    f"Allocated node {node_id} for model {model_name}"
+                                )
+                                node_info["free_gpu"] -= float(num_gpus)
+                                break
+                        if keep_going: # current request is already allocated, check next
+                            continue
+                        if not allocated:
+                            logger.info(f"No available node for model {model_name}")
+                    await self._update_worker_nodes(worker_nodes)
+                    # remove the allocated requests from the `loading_requests` list
+                    loading_requests = [req for req in loading_requests if not req[4].done()] 
+                await asyncio.sleep(1)
+        except Exception as e:
+            logger.error(f"Error: {e}",exc_info=True)
 
     async def _get_worker_nodes(self):
         worker_nodes = get_worker_nodes()

--- a/sllm/serve/schedulers/fcfs_scheduler.py
+++ b/sllm/serve/schedulers/fcfs_scheduler.py
@@ -117,7 +117,7 @@ class FcfsScheduler(SllmScheduler):
                                         allocation_result,
                                     )
                                 )
-                    loading_requests.sort(key= lambda x: x[1])
+                    loading_requests.sort(key=lambda x: x[1])
                 # logger.info(f"Loading requests: {loading_requests}")
                 # first come first serve
                 else:
@@ -139,11 +139,19 @@ class FcfsScheduler(SllmScheduler):
                                     keep_going = True
                                     break
                                 try:
-                                    self.model_loading_queues[model_name].remove((request_time, num_gpus, allocation_result))
-                                except ValueError: 
+                                    self.model_loading_queues[
+                                        model_name
+                                    ].remove(
+                                        (
+                                            request_time,
+                                            num_gpus,
+                                            allocation_result,
+                                        )
+                                    )
+                                except ValueError:
                                     keep_going = True
                                     break
-                                async with self.queue_lock:                              
+                                async with self.queue_lock:
                                     allocation_result.set_result(node_id)
                                 allocated = True
                                 logger.info(
@@ -151,16 +159,22 @@ class FcfsScheduler(SllmScheduler):
                                 )
                                 node_info["free_gpu"] -= float(num_gpus)
                                 break
-                        if keep_going: # current request is already allocated, check next
+                        if (
+                            keep_going
+                        ):  # current request is already allocated, check next
                             continue
                         if not allocated:
-                            logger.info(f"No available node for model {model_name}")
+                            logger.info(
+                                f"No available node for model {model_name}"
+                            )
                     await self._update_worker_nodes(worker_nodes)
                     # remove the allocated requests from the `loading_requests` list
-                    loading_requests = [req for req in loading_requests if not req[4].done()] 
+                    loading_requests = [
+                        req for req in loading_requests if not req[4].done()
+                    ]
                 await asyncio.sleep(1)
         except Exception as e:
-            logger.error(f"Error: {e}",exc_info=True)
+            logger.error(f"Error: {e}", exc_info=True)
 
     async def _get_worker_nodes(self):
         worker_nodes = get_worker_nodes()

--- a/sllm/serve/store_manager.py
+++ b/sllm/serve/store_manager.py
@@ -372,9 +372,12 @@ class StoreManager:
             for node_id, node_info in worker_node_info.items():
                 node_address = node_info["address"]
                 if node_id not in self.local_servers:
-                    self.local_servers[node_id] = SllmLocalStore(
-                        node_id, SllmStoreClient(f"{node_address}:8073"), 1
-                    )
+                    if self.local_servers:
+                        first_node = next(iter(self.local_servers.values()))
+                        self.local_servers[node_id] = SllmLocalStore(
+                        node_id, SllmStoreClient(f"{node_address}:8073"), 1, first_node.chunk_size, first_node.hardware_info)
+                    else:
+                        logger.error("no nodes")
 
             target_nodes = []
             if placement_config and "target_nodes" in placement_config:

--- a/sllm/serve/store_manager.py
+++ b/sllm/serve/store_manager.py
@@ -375,7 +375,12 @@ class StoreManager:
                     if self.local_servers:
                         first_node = next(iter(self.local_servers.values()))
                         self.local_servers[node_id] = SllmLocalStore(
-                        node_id, SllmStoreClient(f"{node_address}:8073"), 1, first_node.chunk_size, first_node.hardware_info)
+                            node_id,
+                            SllmStoreClient(f"{node_address}:8073"),
+                            1,
+                            first_node.chunk_size,
+                            first_node.hardware_info,
+                        )
                     else:
                         logger.error("no nodes")
 


### PR DESCRIPTION
## Description

For the `roundrobin_router`, I changed 2 places:
- `KeyError: popitem(): dictionary is empty` in `_stop_instance` function: instances added to `starting_instances` were still waiting for resource allocation, causing `ready_instances` to be empty when trying to remove an instance. Fix by ensuring we wait until `self.ready_instances` is not empty.
- `RayActorError` when calling ray.kill() with `instance.queue_length > 0`:  I checked the current `stop()` function in the inference backend, it handles unfinished requests there, so this issue is solved. Feel free to ignore it:)

For the `fcfs_scheduler`, I changed the `_control_loop`: 
- Replaced `pop(idx)` with removal by reference to avoid `IndexError: pop index out of range` when previous entries are removed.
- Skip if removal fails or allocation_result is already set. 
- (Optional) Copy and sort `model_loading_queues` once at the beginning, completing all allocation in the current queue before recopying.

## Motivation
These changes solved issues I encountered when trying to run some experiments and sending requests at a high frequency.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).