### PR TITLE
[build] Enhance Workflow Disk Space Management

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Free Up GitHub Actions Ubuntu Runner Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
+          tool-cache: false
+          # All of these default to true, but feel free to set to "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      - name: Free Up GitHub Actions Ubuntu Runner Disk Space
+        shell: bash
+        run: |
+          bash -x .github/workflows/scripts/free-disk-space.sh
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -123,6 +140,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Free Up GitHub Actions Ubuntu Runner Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
+          tool-cache: false
+          # All of these default to true, but feel free to set to "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      - name: Free Up GitHub Actions Ubuntu Runner Disk Space
+        shell: bash
+        run: |
+          bash -x .github/workflows/scripts/free-disk-space.sh
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -188,6 +222,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Free Up GitHub Actions Ubuntu Runner Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
+          tool-cache: false
+          # All of these default to true, but feel free to set to "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
 
       - name: Free Up GitHub Actions Ubuntu Runner Disk Space
         shell: bash


### PR DESCRIPTION
## Description
This PR integrates both `jlumbroso/free-disk-space@main` and `.github/workflows/scripts/free-disk-space.sh`. By combining these, it is now possible to have up to 49GB of disk space. Additionally, the free-up-space script has been added to all publishing workflows to prevent potential space shortages during execution.

## Motivation
To ensure sufficient disk space for workflows by maximizing available free space.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).
