### PR TITLE
fix: download vllm model

### DIFF
--- a/sllm/serve/model_downloader.py
+++ b/sllm/serve/model_downloader.py
@@ -118,23 +118,23 @@ class VllmModelDownloader:
             logger.info(f"{model_path} already exists")
             return
 
+        cache_dir = TemporaryDirectory()
         try:
             if os.path.exists(pretrained_model_name_or_path):
                 input_dir = pretrained_model_name_or_path
             else:
-                with TemporaryDirectory() as cache_dir:
-                    # download from huggingface
-                    input_dir = snapshot_download(
-                        model_name,
-                        cache_dir=cache_dir,
-                        allow_patterns=[
-                            "*.safetensors",
-                            "*.bin",
-                            "*.json",
-                            "*.txt",
-                        ],
-                    )
-            logger.info(input_dir)
+                # download from huggingface
+                input_dir = snapshot_download(
+                    model_name,
+                    cache_dir=cache_dir,
+                    allow_patterns=[
+                        "*.safetensors",
+                        "*.bin",
+                        "*.json",
+                        "*.txt",
+                    ],
+                )
+            logger.info(f"Loading model from {input_dir}")
 
             # load models from the input directory
             llm_writer = LLM(
@@ -173,9 +173,11 @@ class VllmModelDownloader:
                 torch.cuda.empty_cache()
                 torch.cuda.synchronize()
         except Exception as e:
-            print(f"An error occurred while saving the model: {e}")
+            logger.info(f"An error occurred while saving the model: {e}")
             # remove the output dir
             shutil.rmtree(os.path.join(storage_path, "vllm", model_name))
             raise RuntimeError(
                 f"Failed to save {model_name} for vllm backend: {e}"
             )
+        finally:
+            cache_dir.cleanup()

--- a/sllm/serve/model_downloader.py
+++ b/sllm/serve/model_downloader.py
@@ -126,7 +126,7 @@ class VllmModelDownloader:
                 # download from huggingface
                 input_dir = snapshot_download(
                     model_name,
-                    cache_dir=cache_dir,
+                    cache_dir=cache_dir.name,
                     allow_patterns=[
                         "*.safetensors",
                         "*.bin",


### PR DESCRIPTION
## Description
Change to not use context manager for cache dir of `snapshot_download`.
## Motivation
After merging https://github.com/ServerlessLLM/ServerlessLLM/pull/177 , the vLLM downloader was moved outside the working scope of the context manager of the cache dir. Thus, the input dir will be automatically deleted before we start the vLLM instance, and the user will face an error.

Thus, we remove using with context and manually manage the lifetime of the cache dir.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).