### PR TITLE
fix: remove free space to avoid deleting containers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,18 +54,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Free Up GitHub Actions Ubuntu Runner Disk Space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
-          tool-cache: false
-          # All of these default to true, but feel free to set to "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
-      - name: Free Up GitHub Actions Ubuntu Runner Disk Space
         shell: bash
         run: |
           bash -x .github/workflows/scripts/free-disk-space.sh
@@ -105,7 +93,6 @@ jobs:
           echo "wheel_name=${wheel_name}" >> $GITHUB_ENV
           echo "asset_name=${asset_name}" >> $GITHUB_ENV
 
-
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
@@ -139,18 +126,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Free Up GitHub Actions Ubuntu Runner Disk Space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
-          tool-cache: false
-          # All of these default to true, but feel free to set to "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
 
       - name: Free Up GitHub Actions Ubuntu Runner Disk Space
         shell: bash


### PR DESCRIPTION
## Description  
This PR removes the third-party dependency `jlumbroso/free-disk-space@main` because it deletes the Docker containers that are built for publishing to PyPI.

## Motivation  
This change is necessary to prevent the unintended deletion of Docker containers required for the PyPI publishing process.  


## Type of Change  
- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

## Checklist  
- [x] I have read the [CONTRIBUTING](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.  
- [ ] I have updated the tests (if applicable).  
- [ ] I have updated the documentation (if applicable).  
