### PR TITLE
feat: Add embedding model inference for vLLM backend

### DIFF
--- a/examples/embedding/docker-compose.yml
+++ b/examples/embedding/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  # Head Node
+  sllm_head:
+    build:
+      context: ../../
+      dockerfile: Dockerfile  # Ensure this points to your head node Dockerfile
+    image: serverlessllm/sllm-serve
+    container_name: sllm_head
+    environment:
+      - MODEL_FOLDER=${MODEL_FOLDER}
+    ports:
+      - "6379:6379"    # Redis port
+      - "8343:8343"    # ServerlessLLM port
+    networks:
+      - sllm_network
+    command: []
+
+  # Worker Node 0
+  sllm_worker_0:
+    build:
+      context: ../../
+      dockerfile: Dockerfile.worker  # Ensure this points to your worker Dockerfile
+    image: serverlessllm/sllm-serve-worker
+    container_name: sllm_worker_0
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: ["gpu"]
+              device_ids: ["0"] # Assigns GPU 0 to the worker
+    environment:
+      - WORKER_ID=0
+      - STORAGE_PATH=/models
+    networks:
+      - sllm_network
+    volumes:
+      - ${MODEL_FOLDER}:/models
+    command: ["-mem_pool_size", "16", "-registration_required", "true"] # Customize the memory pool size here
+
+networks:
+  sllm_network:
+    driver: bridge
+    name: sllm

--- a/examples/embedding/transformers_backend_example.md
+++ b/examples/embedding/transformers_backend_example.md
@@ -1,0 +1,110 @@
+# ServerlessLLM Example Scripts
+Please follow the [Installation instructions](https://serverlessllm.github.io/docs/stable/getting_started/installation) to have ServerlessLLM successfully installed.
+## Calling Embedding API
+This example shows deploying and calling [all-MiniLM-L12-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2) using transformers backend of ServerlessLLM.
+
+### 1. Environment and Service Setup
+First and foremost, enter the folder where docker compose file is located:
+```bash
+cd ServerlessLLM/examples/docker/
+```
+Set the Model Directory `MODEL_FOLDER` where models will be stored:
+```bash
+export MODEL_FOLDER=/path/to/your/models
+```
+Secondly, in a new terminal, launch the ServerlessLLM services with docker compose. It's important to note that the model `all-MiniLM-L12-v2` is approximately 0.12GB in size (float32), so you'll need to configure the store server with a memory pool of at least 0.12GB to avoid encountering an Out of Memory error. We recommend setting the memory pool size as large as possible. The memory pool size is set to 4GB by default. **If you would like to change the memory pool size, you need to modify the `command` entry for each `sllm_worker_#` service in `docker-compose.yml` as follows**:
+
+```yaml
+command: ["-mem_pool_size", "32", "-registration_required", "true"]
+```
+
+This command line option will set a memory pool size of 32GB for each worker node.
+
+Afterwards, run docker compose to start the service.
+
+```bash
+docker compose up -d --build
+```
+
+### 2. Model Deployment
+Now let's deploy the embedding model.
+
+First, write your deployment configuration `my_config.json`:
+```json
+{
+    "model": "sentence-transformers/all-MiniLM-L12-v2",
+    "backend": "transformers",
+    "num_gpus": 1,
+    "auto_scaling_config": {
+        "metric": "concurrency",
+        "target": 1,
+        "min_instances": 0,
+        "max_instances": 10
+    },
+    "backend_config": {
+        "pretrained_model_name_or_path": "",
+        "device_map": "auto",
+        "torch_dtype": "float32",
+        "hf_model_class": "AutoModel"
+    }
+}
+```
+Next, set the ServerlessLLM Server URL `LLM_SERVER_URL` and deploy this model with the configuration:
+```bash
+conda activate sllm
+export LLM_SERVER_URL=http://127.0.0.1:8343/
+sllm-cli deploy --config /path/to/my_config.json
+```
+
+### 3. Service Request
+Post a request by:
+```bash
+curl http://127.0.0.1:8343/v1/embeddings \
+-H "Content-Type: application/json" \
+-d '{
+        "model": "sentence-transformers/all-MiniLM-L12-v2",
+        "input": [
+           "Hi, How are you?"
+        ]
+    }'
+```
+You will finally receive the response like:
+```bash
+{
+    "object": "list",
+    "data": [
+        {
+            "object": "embedding",
+            "index": 0,
+            "embedding": [
+                0.03510047867894173,
+                0.0419340543448925,
+                0.005905449856072664，
+                ... # (omit for spacing)
+                0.08812830597162247,
+                0.03634589537978172,
+                0.0021678076591342688,
+                0.051571957767009735,
+                0.029966454952955246,
+                0.02055398002266884
+            ]
+        }
+    ],
+    "model": "sentence-transformers/all-MiniLM-L12-v2",
+    "usage": {
+        "query_tokens": 11,
+        "total_tokens": 11
+    }
+}
+```
+
+### 4. Clean Up
+In the end, if you would like to delete the model, please run:
+```bash
+sllm-cli delete sentence-transformers/all-MiniLM-L12-v2
+```
+
+To stop the ServerlessLLM services, please run:
+```bash
+docker compose down
+```

--- a/examples/embedding/transformers_backend_example.md
+++ b/examples/embedding/transformers_backend_example.md
@@ -4,21 +4,15 @@ Please follow the [Installation instructions](https://serverlessllm.github.io/do
 This example shows deploying and calling [all-MiniLM-L12-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2) using transformers backend of ServerlessLLM.
 
 ### 1. Environment and Service Setup
-First and foremost, enter the folder where docker compose file is located:
-```bash
-cd ServerlessLLM/examples/docker/
-```
-Set the Model Directory `MODEL_FOLDER` where models will be stored:
+First and foremost, set the Model Directory `MODEL_FOLDER` where models will be stored:
 ```bash
 export MODEL_FOLDER=/path/to/your/models
 ```
 Secondly, in a new terminal, launch the ServerlessLLM services with docker compose. It's important to note that the model `all-MiniLM-L12-v2` is approximately 0.12GB in size (float32), so you'll need to configure the store server with a memory pool of at least 0.12GB to avoid encountering an Out of Memory error. We recommend setting the memory pool size as large as possible. The memory pool size is set to 4GB by default. **If you would like to change the memory pool size, you need to modify the `command` entry for each `sllm_worker_#` service in `docker-compose.yml` as follows**:
 
 ```yaml
-command: ["-mem_pool_size", "32", "-registration_required", "true"]
+command: ["-mem_pool_size", "32", "-registration_required", "true"] # This command line option will set a memory pool size of 32GB for each worker node.
 ```
-
-This command line option will set a memory pool size of 32GB for each worker node.
 
 Afterwards, run docker compose to start the service.
 
@@ -49,13 +43,14 @@ First, create a deployment configuration and save it as a `json` file:
     }
 }
 ```
-The file `transformers_embed_config.json` is available in the `ServerlessLLM/examples/embedding` directory. Feel free use it. You can also modify it as necessary, or create a new file to suit your requirements.
+
+We have created the file `transformers_embed_config.json`. Feel free use it. You can also modify it as necessary, or create a new file to suit your requirements.
 
 Next, set the ServerlessLLM Server URL `LLM_SERVER_URL` and deploy this model with the configuration:
 ```bash
 conda activate sllm
 export LLM_SERVER_URL=http://127.0.0.1:8343/
-sllm-cli deploy --config ServerlessLLM/examples/embedding/transformers_embed_config.json
+sllm-cli deploy --config transformers_embed_config.json
 ```
 
 ### 3. Service Request

--- a/examples/embedding/transformers_backend_example.md
+++ b/examples/embedding/transformers_backend_example.md
@@ -29,7 +29,7 @@ docker compose up -d --build
 ### 2. Model Deployment
 Now let's deploy the embedding model.
 
-First, write your deployment configuration `my_config.json`:
+First, create a deployment configuration and save it as a `json` file:
 ```json
 {
     "model": "sentence-transformers/all-MiniLM-L12-v2",
@@ -49,11 +49,13 @@ First, write your deployment configuration `my_config.json`:
     }
 }
 ```
+The file `transformers_embed_config.json` is available in the `ServerlessLLM/examples/embedding` directory. Feel free use it. You can also modify it as necessary, or create a new file to suit your requirements.
+
 Next, set the ServerlessLLM Server URL `LLM_SERVER_URL` and deploy this model with the configuration:
 ```bash
 conda activate sllm
 export LLM_SERVER_URL=http://127.0.0.1:8343/
-sllm-cli deploy --config /path/to/my_config.json
+sllm-cli deploy --config ServerlessLLM/examples/embedding/transformers_embed_config.json
 ```
 
 ### 3. Service Request

--- a/examples/embedding/transformers_embed_config.json
+++ b/examples/embedding/transformers_embed_config.json
@@ -1,0 +1,17 @@
+{
+    "model": "sentence-transformers/all-MiniLM-L12-v2",
+    "backend": "transformers",
+    "num_gpus": 1,
+    "auto_scaling_config": {
+        "metric": "concurrency",
+        "target": 1,
+        "min_instances": 0,
+        "max_instances": 10
+    },
+    "backend_config": {
+        "pretrained_model_name_or_path": "",
+        "device_map": "auto",
+        "torch_dtype": "float32",
+        "hf_model_class": "AutoModel"
+    }
+}

--- a/examples/embedding/vllm_backend_example.md
+++ b/examples/embedding/vllm_backend_example.md
@@ -29,7 +29,7 @@ docker compose up -d --build
 ### 2. Model Deployment
 Now let's deploy the embedding model.
 
-First, write your deployment configuration `my_config.json`:
+First, create a deployment configuration and save it as a `json` file:
 ```json
 {
     "model": "intfloat/e5-mistral-7b-instruct",
@@ -53,11 +53,13 @@ First, write your deployment configuration `my_config.json`:
 ```
 **NOTE:** `enable_prefix_caching: false` and `enforce_eager: true` are necessary for current vLLM version.
 
+The file `vllm_embed_config.json` is available in the `ServerlessLLM/examples/embedding` directory. Feel free use it. You can also modify it as necessary, or create a new file to suit your requirements.
+
 Next, set the ServerlessLLM Server URL `LLM_SERVER_URL` and deploy this model with the configuration:
 ```bash
 conda activate sllm
 export LLM_SERVER_URL=http://127.0.0.1:8343/
-sllm-cli deploy --config /path/to/my_config.json
+sllm-cli deploy --config ServerlessLLM/examples/embedding/vllm_embed_config.json
 ```
 
 ### 3. Service Request

--- a/examples/embedding/vllm_backend_example.md
+++ b/examples/embedding/vllm_backend_example.md
@@ -4,21 +4,15 @@ Please follow the [Installation instructions](https://serverlessllm.github.io/do
 This example shows deploying and calling [e5-mistral-7b-instruct](https://huggingface.co/intfloat/e5-mistral-7b-instruct) using vllm backend of ServerlessLLM.
 
 ### 1. Environment and Service Setup
-First and foremost, enter the folder where docker compose file is located:
-```bash
-cd ServerlessLLM/examples/docker/
-```
-Set the Model Directory `MODEL_FOLDER` where models will be stored:
+First and foremost, set the Model Directory `MODEL_FOLDER` where models will be stored:
 ```bash
 export MODEL_FOLDER=/path/to/your/models
 ```
 Secondly, in a new terminal, launch the ServerlessLLM services with docker compose. It's important to note that the model `e5-mistral-7b-instruct` is approximately 14GB in size (float16), so you'll need to configure the store server with a memory pool of at least 14GB to avoid encountering an Out of Memory error. We recommend setting the memory pool size as large as possible. The memory pool size is set to 4GB by default. **If you would like to change the memory pool size, you need to modify the `command` entry for each `sllm_worker_#` service in `docker-compose.yml` as follows**:
 
 ```yaml
-command: ["-mem_pool_size", "32", "-registration_required", "true"]
+command: ["-mem_pool_size", "32", "-registration_required", "true"] # This command line option will set a memory pool size of 32GB for each worker node.
 ```
-
-This command line option will set a memory pool size of 32GB for each worker node.
 
 Afterwards, run docker compose to start the service.
 
@@ -53,13 +47,13 @@ First, create a deployment configuration and save it as a `json` file:
 ```
 **NOTE:** `enable_prefix_caching: false` and `enforce_eager: true` are necessary for current vLLM version.
 
-The file `vllm_embed_config.json` is available in the `ServerlessLLM/examples/embedding` directory. Feel free use it. You can also modify it as necessary, or create a new file to suit your requirements.
+We have created the file `vllm_embed_config.json`. Feel free use it. You can also modify it as necessary, or create a new file to suit your requirements.
 
 Next, set the ServerlessLLM Server URL `LLM_SERVER_URL` and deploy this model with the configuration:
 ```bash
 conda activate sllm
 export LLM_SERVER_URL=http://127.0.0.1:8343/
-sllm-cli deploy --config ServerlessLLM/examples/embedding/vllm_embed_config.json
+sllm-cli deploy --config vllm_embed_config.json
 ```
 
 ### 3. Service Request

--- a/examples/embedding/vllm_embed_config.json
+++ b/examples/embedding/vllm_embed_config.json
@@ -1,0 +1,19 @@
+{
+    "model": "intfloat/e5-mistral-7b-instruct",
+    "backend": "vllm",
+    "num_gpus": 1,
+    "auto_scaling_config": {
+        "metric": "concurrency",
+        "target": 1,
+        "min_instances": 0,
+        "max_instances": 10,
+        "keep_alive": 0
+    },
+    "backend_config": {
+        "pretrained_model_name_or_path": "intfloat/e5-mistral-7b-instruct",
+        "enforce_eager": true,
+        "enable_prefix_caching": false,
+        "device_map": "auto",
+        "torch_dtype": "float16"
+    }
+}

--- a/tests/backend_test/vllm_backend_test.py
+++ b/tests/backend_test/vllm_backend_test.py
@@ -20,7 +20,12 @@ from typing import AsyncIterator
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from vllm import CompletionOutput, RequestOutput
+from vllm import (
+    CompletionOutput,
+    EmbeddingOutput,
+    EmbeddingRequestOutput,
+    RequestOutput,
+)
 
 from sllm.serve.backends.vllm_backend import (
     BackendStatus,
@@ -77,6 +82,26 @@ async def generate(
     )
 
 
+# Mock the encode method
+async def encode(
+    inputs, pooling_params, request_id
+) -> AsyncIterator[EmbeddingRequestOutput]:
+    # Simulate the behavior of real encode with multiple embeddings
+    yield EmbeddingRequestOutput(
+        request_id=request_id,
+        outputs=EmbeddingOutput(embedding=[0.1, 0.2, 0.3]),
+        prompt_token_ids=[101, 102, 103],
+        finished=True,
+    )
+    await asyncio.sleep(1)
+    yield EmbeddingRequestOutput(
+        request_id=request_id,
+        outputs=EmbeddingOutput(embedding=[0.4, 0.5, 0.6]),
+        prompt_token_ids=[104, 105, 106],
+        finished=True,
+    )
+
+
 @pytest.fixture
 def async_llm_engine():
     with patch(
@@ -88,6 +113,7 @@ def async_llm_engine():
         )
         async_llm_engine_obj.abort = AsyncMock()
         async_llm_engine_obj.generate.side_effect = generate
+        async_llm_engine_obj.encode.side_effect = encode
         yield async_llm_engine_obj
 
 
@@ -114,7 +140,7 @@ async def test_init_backend(vllm_backend, async_llm_engine):
 @pytest.mark.asyncio
 async def test_generate_without_init(vllm_backend):
     request_data = {
-        "model_name": "test-model",
+        "model": "test-model",
         "prompt": "user: Hello",
         "request_id": "test-request-id",
     }
@@ -129,7 +155,7 @@ async def test_generate_without_init(vllm_backend):
 @pytest.mark.asyncio
 async def test_generate(vllm_backend, async_llm_engine):
     request_data = {
-        "model_name": "test-model",
+        "model": "test-model",
         "prompt": "user: Hello",
         "request_id": "test-request-id",
     }
@@ -150,7 +176,7 @@ async def test_shutdown(model_name, backend_config, async_llm_engine):
     backend_config["trace_debug"] = True
     vllm_backend = VllmBackend(model_name, backend_config)
     request_data = {
-        "model_name": "test-model",
+        "model": "test-model",
         "prompt": "user: Hello",
         "request_id": "test-request-id",
     }
@@ -169,7 +195,7 @@ async def test_shutdown(model_name, backend_config, async_llm_engine):
 @pytest.mark.asyncio
 async def test_stop(vllm_backend, async_llm_engine):
     request_data = {
-        "model_name": "test-model",
+        "model": "test-model",
         "prompt": "user: Hello",
         "request_id": "test-request-id",
     }
@@ -198,7 +224,7 @@ async def test_get_current_tokens(model_name, backend_config, async_llm_engine):
     vllm_backend = VllmBackend(model_name, backend_config)
     request_data = [
         {
-            "model_name": "test-model",
+            "model": "test-model",
             "prompt": "user: Hello",
             "request_id": f"test-request-id{i}",
         }
@@ -226,3 +252,24 @@ async def test_resume_kv_cache(vllm_backend):
     request_datas = [[1, 2, 3], [4, 5, 6]]
     await vllm_backend.resume_kv_cache(request_datas)
     assert vllm_backend.generate.call_count == len(request_datas)
+
+
+@pytest.mark.asyncio
+async def test_encode(backend_config, async_llm_engine, model_name):
+    backend_config["enforce_eager"] = True
+    backend_config["enable_prefix_caching"] = False
+    vllm_backend = VllmBackend(model_name, backend_config)
+
+    request_data = {"model": "test-model", "input": ["Hi, How are you?"]}
+
+    with patch(
+        "sllm.serve.backends.vllm_backend.AsyncLLMEngine.from_engine_args",
+        return_value=async_llm_engine,
+    ):
+        await vllm_backend.init_backend()
+
+    result = await vllm_backend.encode(request_data)
+
+    assert "error" not in result
+    assert "data" in result
+    assert len(result["data"]) == 2


### PR DESCRIPTION
## Description
Add embedding API using vLLM backend.

## Motivation
The embedding API is currently supported only by the transformers backend. Since vLLM (starting from version 0.4.3) now also supports running embedding models, the corresponding embedding API should be incorporated into sllm as well.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [x] I have updated the tests (if applicable).
- [x] I have updated the documentation (if applicable).