### PR TITLE
fix: update router & scheduler

### DIFF
--- a/sllm/serve/routers/roundrobin_router.py
+++ b/sllm/serve/routers/roundrobin_router.py
@@ -312,6 +312,9 @@ class RoundRobinRouter(SllmRouter):
         return instance_id
 
     async def _stop_instance(self, instance_id: Optional[str] = None):
+        while len(self.ready_instances) <= 0:
+            await asyncio.sleep(1)
+            
         async with self.instance_management_lock:
             if instance_id is None:
                 instance_id, instance = self.ready_instances.popitem()

--- a/sllm/serve/schedulers/fcfs_scheduler.py
+++ b/sllm/serve/schedulers/fcfs_scheduler.py
@@ -146,22 +146,30 @@ class FcfsScheduler(SllmScheduler):
                     allocated = False
                     keep_going = False
                     for node_id, node_info in worker_nodes.items():
-                        async with self.queue_lock:
-                            if node_info["free_gpu"] >= num_gpus:
+                        if node_info["free_gpu"] >= num_gpus:
+                            async with self.queue_lock:
                                 if allocation_result.done():
                                     keep_going = True
                                     break
                                 try:
-                                    self.model_loading_queues[model_name].remove((request_time, num_gpus, allocation_result))
-                                except ValueError: 
+                                    self.model_loading_queues[
+                                        model_name
+                                    ].remove(
+                                        (
+                                            request_time,
+                                            num_gpus,
+                                            allocation_result,
+                                        )
+                                    )
+                                    allocation_result.set_result(node_id)
+                                except ValueError:
                                     keep_going = True
-                                    break                       
-                                allocation_result.set_result(node_id)
-                                allocated = True
-                                logger.info(
-                                    f"Allocated node {node_id} for model {model_name}"
-                                )
-                                node_info["free_gpu"] -= num_gpus
+                                    break
+                            allocated = True
+                            logger.info(
+                                f"Allocated node {node_id} for model {model_name}"
+                            )
+                            node_info["free_gpu"] -= num_gpus
                             break
                     if keep_going:
                         continue

--- a/sllm/serve/schedulers/fcfs_scheduler.py
+++ b/sllm/serve/schedulers/fcfs_scheduler.py
@@ -144,17 +144,27 @@ class FcfsScheduler(SllmScheduler):
                     allocation_result,
                 ) in loading_requests:
                     allocated = False
+                    keep_going = False
                     for node_id, node_info in worker_nodes.items():
-                        if node_info["free_gpu"] >= num_gpus:
-                            async with self.queue_lock:
-                                self.model_loading_queues[model_name].pop(idx)
+                        async with self.queue_lock:
+                            if node_info["free_gpu"] >= num_gpus:
+                                if allocation_result.done():
+                                    keep_going = True
+                                    break
+                                try:
+                                    self.model_loading_queues[model_name].remove((request_time, num_gpus, allocation_result))
+                                except ValueError: 
+                                    keep_going = True
+                                    break                       
                                 allocation_result.set_result(node_id)
-                            allocated = True
-                            logger.info(
-                                f"Allocated node {node_id} for model {model_name}"
-                            )
-                            node_info["free_gpu"] -= num_gpus
+                                allocated = True
+                                logger.info(
+                                    f"Allocated node {node_id} for model {model_name}"
+                                )
+                                node_info["free_gpu"] -= num_gpus
                             break
+                    if keep_going:
+                        continue
                     if not allocated:
                         logger.info(f"No available node for model {model_name}")
                 await self._update_worker_nodes(worker_nodes)

--- a/sllm/serve/store_manager.py
+++ b/sllm/serve/store_manager.py
@@ -369,8 +369,13 @@ class StoreManager:
             for node_id, node_info in worker_node_info.items():
                 node_address = node_info["address"]
                 if node_id not in self.local_servers:
-                    logger.error(f"Node {node_id} not found")
-                    raise ValueError(f"Node {node_id} not found")
+                    if self.local_servers:
+                        first_node = next(iter(self.local_servers.values()))
+                        self.local_servers[node_id] = SllmLocalStore(
+                        node_id, SllmStoreClient(f"{node_address}:8073"), 1, first_node.chunk_size, first_node.hardware_info)
+                    else:
+                        logger.error(f"Node {node_id} not found")
+                        raise ValueError(f"Node {node_id} not found")
 
             local_disk = []
             if placement_config and "local_disk" in placement_config:


### PR DESCRIPTION
## Description
This updates PR #180 , focusing on bug fixes and merging upstream changes. Below is a summary of changes:
- roundrobin_router: 
  - In `_stop_instance` function, add a check to ensure `self.ready_instances` is not empty (might still be waiting for resource allocation) before calling `popitem()`.
- fcfs_scheduler:
  - Replaced `pop(idx)` to avoid `IndexError` when previous entries are removed. Skip if removal fails or allocation_result is already set.
- store_manager: 
  - If 2 workers on the same node, create the second `SllmLocalStore` by copying the same chunksize and hardware info from the existing one.

## Motivation
This update is based on our previous discussion regarding PR #180.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).