### PR TITLE
fix: add max queue length

### DIFF
--- a/sllm/serve/utils.py
+++ b/sllm/serve/utils.py
@@ -87,6 +87,10 @@ class InstanceHandle:
             self.concurrency += num_requests
             return True
 
+    async def check_request_queue(self):
+        async with self.lock:
+            return self.concurrency + 1 <= self.max_queue_length
+
     async def get_status(self):
         async with self.lock:
             return InstanceStatus(


### PR DESCRIPTION
## Description
This closes issue #184.

Fix the `max_queue_length` for model instances, aligning it with the concurrency limit defined in the configuration file.
Add a function in `InstanceHandle` class to check if the current instance can accept one more request. If no slots are available, we will let the next request to go to another instance or wait.


## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).