### PR TITLE
Docs: use pre-built docker image to ease test

### DIFF
--- a/docs/stable/getting_started/docker_quickstart.md
+++ b/docs/stable/getting_started/docker_quickstart.md
@@ -43,7 +43,7 @@ Replace /path/to/your/models with the actual path where you want to store the mo
 Start the ServerlessLLM services using docker compose:
 
 ```bash
-docker compose up -d --build
+docker compose up -d
 ```
 
 This command will start the Ray head node and two worker nodes defined in the `docker-compose.yml` file.

--- a/docs/stable/serve/live_migration.md
+++ b/docs/stable/serve/live_migration.md
@@ -49,7 +49,7 @@ The Docker Compose configuration is already located in the `examples/live_migrat
 1. **Start the ServerlessLLM Services Using Docker Compose**
 
 ```bash
-docker compose up -d --build
+docker compose up -d
 ```
 
 This command will start the Ray head node and two worker nodes defined in the `docker-compose.yml` file.
@@ -122,7 +122,7 @@ docker compose down
 Use the following command to start the ServerlessLLM services with live migration enabled. This configuration includes the `enable-migration.yml` file:
 
 ```bash
-docker compose -f docker-compose.yml -f enable-migration.yml up -d --build
+docker compose -f docker-compose.yml -f enable-migration.yml up -d
 ```
 
 This command will start the Ray head node and two worker nodes, enabling the live migration feature.

--- a/docs/stable/serve/storage_aware_scheduling.md
+++ b/docs/stable/serve/storage_aware_scheduling.md
@@ -45,7 +45,7 @@ Recommend to adjust the number of GPUs and `mem_pool_size` based on the resource
 Start the ServerlessLLM services using Docker Compose:
 
 ```bash
-docker compose up -d --build
+docker compose up -d
 ```
 
 This command will start the Ray head node and two worker nodes defined in the `docker-compose.yml` file.

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -3,7 +3,7 @@
 To quickly set up a local ServerlessLLM cluster using Docker Compose, follow these steps:
 ```bash
 export MODEL_FOLDER=/path/to/models
-docker compose up -d --build
+docker compose up -d
 ```
 
 Note: Make sure you have Docker installed on your system and NVIDIA GPUs available. For detailed instructions, refer to the [Docker Quickstart Guide](https://serverlessllm.github.io/docs/stable/getting_started/docker_quickstart).

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../
       dockerfile: Dockerfile  # Ensure this points to your head node Dockerfile
-    image: serverlessllm/sllm-serve
+    image: serverlessllm/sllm-head:latest
     container_name: sllm_head
     environment:
       - MODEL_FOLDER=${MODEL_FOLDER}
@@ -20,7 +20,7 @@ services:
     build:
       context: ../../
       dockerfile: Dockerfile.worker  # Ensure this points to your worker Dockerfile
-    image: serverlessllm/sllm-serve-worker
+    image: serverlessllm/sllm-worker:latest
     container_name: sllm_worker_0
     deploy:
       resources:
@@ -43,7 +43,7 @@ services:
   #   build:
   #     context: ../../
   #     dockerfile: Dockerfile.worker
-  #   image: serverlessllm/sllm-serve-worker
+  #   image: serverlessllm/sllm-worker:latest
   #   container_name: sllm_worker_1
   #   deploy:
   #     resources:

--- a/examples/embedding/README.md
+++ b/examples/embedding/README.md
@@ -23,7 +23,7 @@ This command line option will set a memory pool size of 32GB for each worker nod
 Afterwards, run docker compose to start the service.
 
 ```bash
-docker compose up -d --build
+docker compose up -d
 ```
 
 ### 2. Model Deployment

--- a/examples/embedding/docker-compose.yml
+++ b/examples/embedding/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../
       dockerfile: Dockerfile  # Ensure this points to your head node Dockerfile
-    image: serverlessllm/sllm-serve
+    image: serverlessllm/sllm-head:latest
     container_name: sllm_head
     environment:
       - MODEL_FOLDER=${MODEL_FOLDER}
@@ -20,7 +20,7 @@ services:
     build:
       context: ../../
       dockerfile: Dockerfile.worker  # Ensure this points to your worker Dockerfile
-    image: serverlessllm/sllm-serve-worker
+    image: serverlessllm/sllm-worker:latest
     container_name: sllm_worker_0
     deploy:
       resources:

--- a/examples/live_migration/README.md
+++ b/examples/live_migration/README.md
@@ -1,7 +1,7 @@
 # ServerlessLLM Docker Compose Quickstart
 
 ```bash
-docker compose -f docker-compose.yml -f enable-migration.yml up -d --build
+docker compose -f docker-compose.yml -f enable-migration.yml up -d
 ```
 
 ```bash

--- a/examples/live_migration/docker-compose.yml
+++ b/examples/live_migration/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../
       dockerfile: Dockerfile  # Ensure this points to your head node Dockerfile
-    image: serverlessllm/sllm-serve
+    image: serverlessllm/sllm-head:latest
     container_name: sllm_head
     environment:
       - MODEL_FOLDER=${MODEL_FOLDER}
@@ -20,7 +20,7 @@ services:
     build:
       context: ../../
       dockerfile: Dockerfile.worker  # Ensure this points to your worker Dockerfile
-    image: serverlessllm/sllm-serve-worker
+    image: serverlessllm/sllm-worker:latest
     container_name: sllm_worker_0
     deploy:
       resources:
@@ -43,7 +43,7 @@ services:
     build:
       context: ../../
       dockerfile: Dockerfile.worker
-    image: serverlessllm/sllm-serve-worker
+    image: serverlessllm/sllm-worker:latest
     container_name: sllm_worker_1
     deploy:
       resources:

--- a/examples/storage_aware_scheduling/docker-compose.yml
+++ b/examples/storage_aware_scheduling/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../
       dockerfile: Dockerfile  # Ensure this points to your head node Dockerfile
-    image: serverlessllm/sllm-serve
+    image: serverlessllm/sllm-head:latest
     container_name: sllm_head
     environment:
       - MODEL_FOLDER=${MODEL_FOLDER}
@@ -20,7 +20,7 @@ services:
     build:
       context: ../../
       dockerfile: Dockerfile.worker  # Ensure this points to your worker Dockerfile
-    image: serverlessllm/sllm-serve-worker
+    image: serverlessllm/sllm-worker:latest
     container_name: sllm_worker_0
     deploy:
       resources:
@@ -43,7 +43,7 @@ services:
     build:
       context: ../../
       dockerfile: Dockerfile.worker  # Ensure this points to your worker Dockerfile
-    image: serverlessllm/sllm-serve-worker
+    image: serverlessllm/sllm-worker:latest
     container_name: sllm_worker_1
     deploy:
       resources:


### PR DESCRIPTION
## Description
Updated all `docker compose up` commands to use pre-built Docker images from Docker Hub instead of building locally with the `--build` flag. The official Docker images have been uploaded to Docker Hub: [sllm-worker](https://hub.docker.com/r/serverlessllm/sllm-worker) and [sllm-head](https://hub.docker.com/r/serverlessllm/sllm-head).

Renamed images:
- `serverlessllm/sllm-serve-worker` → `serverlessllm/sllm-worker`
- `serverlessllm/sllm-serve` → `serverlessllm/sllm-head`

## Motivation
This change reduces user testing time by avoiding the need to rebuild images locally.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [x] I have updated the documentation (if applicable).
