### PR TITLE
URGENT FIX: pip install issues

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include requirements.txt
+include requirements-worker.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[options.data_files]
-. = requirements.txt

--- a/sllm_store/MANIFEST.in
+++ b/sllm_store/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include csrc *.cpp *.h *.cc
+include requirements.txt
 include CMakeLists.txt
 include cmake/utils.cmake
 include proto/storage.proto


### PR DESCRIPTION
## Description
Include `requirements.txt` in `MANIFEST.in` to ensure it's part of the released package.

## Motivation
The `pip install serverless-llm-store` command fails due to the missing `requirements.txt` in the distributed package.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [x] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).