### PR TITLE
fix: link check

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ServerlessLLM (`sllm`, pronounced "slim") is an open-source serverless framework
 
 ## News
 
-- **[11/24]** We have added experimental support of fast checkpoint loading for AMD GPUs (ROCm) when using with vLLM, PyTorch and HuggingFace Accelerate. Please refer to the [documentation](https://serverlessllm.github.io/docs/stable/store/installation_with_rocm) for more details.
+- **[11/24]** We have added experimental support of fast checkpoint loading for AMD GPUs (ROCm) when using with vLLM, PyTorch and HuggingFace Accelerate. Please refer to the [documentation](https://serverlessllm.github.io/docs/stable/store/rocm_quickstart) for more details.
 - **[10/24]** ServerlessLLM was invited to present at a global AI tech vision forum in Singapore.
 - **[10/24]** We hosted the first ServerlessLLM developer meetup in Edinburgh, attracting over 50 attendees both offline and online. Together, we brainstormed many exciting new features to develop. If you have great ideas, we’d love for you to join us!
 - **[10/24]** We made the first public release of ServerlessLLM. Check out the details of the release [here](https://github.com/ServerlessLLM/ServerlessLLM/releases/tag/v0.5.0).

--- a/sllm_store/README.md
+++ b/sllm_store/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-`sllm-store` is an internal library of ServerlessLLM that provides high-performance model loading from local storage into GPU memory. It can also be installed and used independently in other projects. For more details, see our [quick start guide](https://serverlessllm.github.io/docs/stable/store/quickstart). For experimental support for ROCm, see our [ROCm guide](https://serverlessllm.github.io/docs/stable/store/installation_with_rocm).
+`sllm-store` is an internal library of ServerlessLLM that provides high-performance model loading from local storage into GPU memory. It can also be installed and used independently in other projects. For more details, see our [quick start guide](https://serverlessllm.github.io/docs/stable/store/quickstart). For support for ROCm, see our [ROCm guide](https://serverlessllm.github.io/docs/stable/store/rocm_quickstart).
 
 ## Installation
 


### PR DESCRIPTION
## Description
Fix the link check issue

## Motivation
In our previous document, the link for ROCm support is outdated, which will lead to an link check failure. I've changed all of them to the latest (https://serverlessllm.github.io/docs/stable/store/rocm_quickstart)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [x] I have updated the documentation (if applicable).