### PR TITLE
fix: sllm_store requirements

### DIFF
--- a/sllm_store/requirements.txt
+++ b/sllm_store/requirements.txt
@@ -2,5 +2,6 @@ accelerate==0.29.3
 click>=8.1.7
 grpcio==1.49.1
 grpcio-tools==1.49.1
+peft==0.8.2
 torch==2.3.0
 transformers==4.42.0


### PR DESCRIPTION
## Description
Add `peft==0.8.2` into `sllm_store`'s `requirements.txt`
## Motivation
If not, when only install the prebuilt wheel of `sllm_store`, it will not install `peft` and raise an error when trying to save or load model.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).