### PR TITLE
feat: support stream generate for transformers backend

### DIFF
--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -7,6 +7,7 @@ grpcio-tools==1.49.1
 # This is to fix issue: https://github.com/dottxt-ai/outlines/issues/1198
 outlines==0.0.43
 peft==0.8.2
+shortuuid==1.0.13
 speedtest-cli==2.1.3
 torch==2.3.0
 transformers==4.42.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pydantic_core==2.16.2
 ray==2.9.0
 requests==2.32.2
 serverless-llm-store
+shortuuid==1.0.13
 speedtest-cli==2.1.3
 types-requests==2.31.0.20240125
 uvicorn[standard]==0.23.1

--- a/sllm/serve/app_lib.py
+++ b/sllm/serve/app_lib.py
@@ -121,7 +121,7 @@ def create_app() -> FastAPI:
         logger.info(f"Got request router for {model_name}")
 
         if body.get("stream", False):
-            generator = request_router.inference_stream.remote(body)
+            generator = request_router.generate_stream.remote(body)
             chat_generator = chat_completion_stream_generator(
                 model_name, generator
             )

--- a/sllm/serve/backends/transformers_backend.py
+++ b/sllm/serve/backends/transformers_backend.py
@@ -228,6 +228,14 @@ class TransformersBackend(SllmBackend):
 
         return response
 
+    def generate_text(self, inputs, streamer, temperature, max_new_tokens):
+        self.model.generate(
+            inputs.input_ids,
+            streamer=streamer,
+            temperature=temperature,
+            max_new_tokens=max_new_tokens,
+        )
+
     async def generate_stream(self, request_data: Optional[Dict[str, Any]]):
         with self.status_lock:
             if self.status != BackendStatus.RUNNING:

--- a/sllm/serve/openai_api_protocol.py
+++ b/sllm/serve/openai_api_protocol.py
@@ -1,0 +1,244 @@
+import time
+from typing import Any, Dict, List, Literal, Optional, Union
+
+import shortuuid
+from pydantic import BaseModel, Field
+
+
+class ErrorResponse(BaseModel):
+    object: str = "error"
+    message: str
+    code: int
+
+
+class ModelPermission(BaseModel):
+    id: str = Field(default_factory=lambda: f"modelperm-{shortuuid.random()}")
+    object: str = "model_permission"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    allow_create_engine: bool = False
+    allow_sampling: bool = True
+    allow_logprobs: bool = True
+    allow_search_indices: bool = True
+    allow_view: bool = True
+    allow_fine_tuning: bool = False
+    organization: str = "*"
+    group: Optional[str] = None
+    is_blocking: str = False
+
+
+class ModelCard(BaseModel):
+    id: str
+    object: str = "model"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    owned_by: str = "fastchat"
+    root: Optional[str] = None
+    parent: Optional[str] = None
+    permission: List[ModelPermission] = []
+
+
+class ModelList(BaseModel):
+    object: str = "list"
+    data: List[ModelCard] = []
+
+
+class UsageInfo(BaseModel):
+    prompt_tokens: int = 0
+    total_tokens: int = 0
+    completion_tokens: Optional[int] = 0
+
+
+class LogProbs(BaseModel):
+    text_offset: List[int] = Field(default_factory=list)
+    token_logprobs: List[Optional[float]] = Field(default_factory=list)
+    tokens: List[str] = Field(default_factory=list)
+    top_logprobs: List[Optional[Dict[str, float]]] = Field(default_factory=list)
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str
+    messages: Union[
+        str,
+        List[Dict[str, str]],
+        List[
+            Dict[str, Union[str, List[Dict[str, Union[str, Dict[str, str]]]]]]
+        ],
+    ]
+    temperature: Optional[float] = 0.7
+    top_p: Optional[float] = 1.0
+    top_k: Optional[int] = -1
+    n: Optional[int] = 1
+    max_tokens: Optional[int] = None
+    stop: Optional[Union[str, List[str]]] = None
+    stream: Optional[bool] = False
+    presence_penalty: Optional[float] = 0.0
+    frequency_penalty: Optional[float] = 0.0
+    user: Optional[str] = None
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ChatCompletionResponseChoice(BaseModel):
+    index: int
+    message: ChatMessage
+    finish_reason: Optional[Literal["stop", "length"]] = None
+
+
+class ChatCompletionResponse(BaseModel):
+    id: str = Field(default_factory=lambda: f"chatcmpl-{shortuuid.random()}")
+    object: str = "chat.completion"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    choices: List[ChatCompletionResponseChoice]
+    usage: UsageInfo
+
+
+class DeltaMessage(BaseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+class ChatCompletionResponseStreamChoice(BaseModel):
+    index: int
+    delta: DeltaMessage
+    finish_reason: Optional[Literal["stop", "length"]] = None
+
+
+class ChatCompletionStreamResponse(BaseModel):
+    id: str = Field(default_factory=lambda: f"chatcmpl-{shortuuid.random()}")
+    object: str = "chat.completion.chunk"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    choices: List[ChatCompletionResponseStreamChoice]
+
+
+class TokenCheckRequestItem(BaseModel):
+    model: str
+    prompt: str
+    max_tokens: int
+
+
+class TokenCheckRequest(BaseModel):
+    prompts: List[TokenCheckRequestItem]
+
+
+class TokenCheckResponseItem(BaseModel):
+    fits: bool
+    tokenCount: int
+    contextLength: int
+
+
+class TokenCheckResponse(BaseModel):
+    prompts: List[TokenCheckResponseItem]
+
+
+class EmbeddingsRequest(BaseModel):
+    model: Optional[str] = None
+    engine: Optional[str] = None
+    input: Union[str, List[Any]]
+    user: Optional[str] = None
+    encoding_format: Optional[str] = None
+
+
+class EmbeddingsResponse(BaseModel):
+    object: str = "list"
+    data: List[Dict[str, Any]]
+    model: str
+    usage: UsageInfo
+
+
+class CompletionRequest(BaseModel):
+    model: str
+    prompt: Union[str, List[Any]]
+    suffix: Optional[str] = None
+    temperature: Optional[float] = 0.7
+    n: Optional[int] = 1
+    max_tokens: Optional[int] = 16
+    stop: Optional[Union[str, List[str]]] = None
+    stream: Optional[bool] = False
+    top_p: Optional[float] = 1.0
+    top_k: Optional[int] = -1
+    logprobs: Optional[int] = None
+    echo: Optional[bool] = False
+    presence_penalty: Optional[float] = 0.0
+    frequency_penalty: Optional[float] = 0.0
+    user: Optional[str] = None
+    use_beam_search: Optional[bool] = False
+    best_of: Optional[int] = None
+
+
+class CompletionResponseChoice(BaseModel):
+    index: int
+    text: str
+    logprobs: Optional[LogProbs] = None
+    finish_reason: Optional[Literal["stop", "length"]] = None
+
+
+class CompletionResponse(BaseModel):
+    id: str = Field(default_factory=lambda: f"cmpl-{shortuuid.random()}")
+    object: str = "text_completion"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    choices: List[CompletionResponseChoice]
+    usage: UsageInfo
+
+
+class CompletionResponseStreamChoice(BaseModel):
+    index: int
+    text: str
+    logprobs: Optional[LogProbs] = None
+    finish_reason: Optional[Literal["stop", "length"]] = None
+
+
+class CompletionStreamResponse(BaseModel):
+    id: str = Field(default_factory=lambda: f"cmpl-{shortuuid.random()}")
+    object: str = "text_completion"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    choices: List[CompletionResponseStreamChoice]
+
+
+async def chat_completion_stream_generator(model_name, generator):
+    id = f"chatcmpl-{shortuuid.random()}"
+
+    # first chunk with role
+    choice_data = ChatCompletionResponseStreamChoice(
+        index=0, delta=DeltaMessage(role="assistant"), finish_reason=None
+    )
+    chunk = ChatCompletionStreamResponse(
+        id=id,
+        choices=[choice_data],
+        model=model_name,
+    )
+    yield f"data: {chunk.model_dump_json(exclude_unset=True)}\n\n"
+
+    async for val in generator:
+        text = await val
+        if text == "":
+            continue
+
+        choice_data = ChatCompletionResponseStreamChoice(
+            index=0,
+            delta=DeltaMessage(content=text),
+            finish_reason=None,
+        )
+        chunk = ChatCompletionStreamResponse(
+            id=id, choices=[choice_data], model=model_name
+        )
+        yield f"data: {chunk.model_dump_json(exclude_unset=True)}\n\n"
+
+    # last chunk for finish reason
+    # TODO: for now, it will only return stop finish reason
+    choice_data = ChatCompletionResponseStreamChoice(
+        index=0,
+        delta=DeltaMessage(content=""),
+        finish_reason="stop",
+    )
+    chunk = ChatCompletionStreamResponse(
+        id=id, choices=[choice_data], model=model_name
+    )
+    yield f"data: {chunk.model_dump_json(exclude_unset=True)}\n\n"
+
+    yield "data: [DONE]\n\n"

--- a/sllm/serve/routers/roundrobin_router.py
+++ b/sllm/serve/routers/roundrobin_router.py
@@ -148,9 +148,16 @@ class RoundRobinRouter(SllmRouter):
         # Looks like a known issue:
         # https://github.com/ray-project/ray/issues/26283#issuecomment-1780691475
         if action == "generate":
-            result = await instance.backend_instance.generate.remote(
-                request_data=request_data
-            )
+            # TODO 测试直接传递generator是否可行
+            if request_data.get("stream", False):
+                result = instance.backend_instance.generate_stream.options(
+                    num_returns="streaming"
+                ).remote(request_data=request_data)
+            else:
+                result = await instance.backend_instance.generate.remote(
+                    request_data=request_data
+                )
+
         elif action == "encode":
             result = await instance.backend_instance.encode.remote(
                 request_data=request_data


### PR DESCRIPTION
## Description
Support stream generate in /v1/chat/completions API for transformers backend.

First version commit, it will conflict with `InferenceStatus` in `transformers_backend.py`, maybe we can discuss how to merge the two streamer, and any other suggestions will be apprecaited.

## Motivation
As described in #176 , it's a common feature in chat API to support stream generate, this pr aims to add this feature.
close #176 .

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).