### PR TITLE
fix: remove duplicate vllm patch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,10 +62,6 @@ initialize_worker_node() {
   echo "Activating worker conda environment..."
   conda activate worker
 
-  # Patch the vLLM code
-  VLLM_PATH=$(python -c "import vllm; import os; print(os.path.dirname(os.path.abspath(vllm.__file__)))")
-  patch -p2 -d "$VLLM_PATH" < ./vllm_patch/sllm_load.patch
-
   # Start the worker
   RAY_HEAD_ADDRESS="${RAY_HEAD_ADDRESS:-$DEFAULT_RAY_HEAD_ADDRESS}"
 


### PR DESCRIPTION
## Description
Remove duplicate vllm patch in `entrypoint.sh`
## Motivation
vllm patch is already applied inside the docker build stage. Thus,`entrypoint.sh`'s apply of it is duplicate and will trigger error when trying to start docker compose.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).