### PR TITLE
fix: set fixed cmake version

### DIFF
--- a/sllm_store/pyproject.toml
+++ b/sllm_store/pyproject.toml
@@ -2,9 +2,9 @@
 requires = [
     "setuptools",
     "wheel",
-    "cmake>=3.20",
+    "cmake>=3.20,<4.0.0",
     "ninja",
-    "torch==2.3.0",
+    "torch==2.5.1",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/sllm_store/requirements-build.txt
+++ b/sllm_store/requirements-build.txt
@@ -1,4 +1,4 @@
-cmake>=3.20
+cmake>=3.20,<4.0.0
 ninja
 peft==0.8.2
 setuptools


### PR DESCRIPTION
## Description
Fix the CMake version when build `sllm_store` to set it to less than 4.0.0

## Motivation
Now `pip install cmake` will install `cmake==4.0.0` (https://pypi.org/project/cmake/#history). When building `sllm_store`, it will raise an error: (see https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features)
```
2.275 CMake Error at build/temp.linux-x86_64-cpython-310/_deps/glog-src/cmake/GetCacheVariables.cmake:2 (c
make_policy):
2.275   Compatibility with CMake < 3.5 has been removed from CMake.
2.275
2.275   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
2.275   to tell CMake that the project requires at least <min> but has been updated
2.275   to work with policies introduced by <max> or earlier.
2.275
2.275   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
2.275 Call Stack (most recent call first):
2.275   build/temp.linux-x86_64-cpython-310/_deps/glog-src/CMakeLists.txt:34 (include)
2.275
2.275
2.275 -- Configuring incomplete, errors occurred!
```
We temporarily set the version range of `sllm_store` between `3.20` and `4.0.0` to avoid this issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).