### PR TITLE
Fix chunk calculation and vLLM model unloading bugs in StoreManager

### DIFF
--- a/sllm_store/csrc/sllm_store/model.cpp
+++ b/sllm_store/csrc/sllm_store/model.cpp
@@ -446,12 +446,12 @@ int Model::FreeHost() {
   std::unique_lock<std::mutex> lock(mutex_);
   if (state_ == MemoryState::UNINITIALIZED) {
     LOG(WARNING) << "Model " << model_path_ << " is not initialized";
-    return 0;
+    return 1;
   }
 
   if (state_ == MemoryState::UNALLOCATED) {
     LOG(WARNING) << "Model " << model_path_ << " is not allocated";
-    return 0;
+    return 1;
   }
 
   if (state_ == MemoryState::LOADING) {
@@ -478,7 +478,7 @@ int Model::FreeHost() {
   pinned_mem_.reset();
   state_ = MemoryState::UNALLOCATED;
 
-  return freed_chunks;
+  return 0;
 }
 
 int Model::TryFreeHost() {


### PR DESCRIPTION
## Description

This PR fixes chunk calculation errors in the `StoreManager`, resolves model unloading issues when using vLLM checkpoints, and corrects the return value of `FreeHost`.

## Motivation

These fixes address critical bugs that impact model management and memory handling, particularly when working with vLLM with storage-aware scheduler.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).
