### PR TITLE
fix: update ubuntu-20.04 to ubuntu-latest in workflows

### DIFF
--- a/.github/workflows/cli_test.yaml
+++ b/.github/workflows/cli_test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     cli_tests:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Spellcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: rojopolis/spellcheck-github-actions@0.40.0
@@ -18,7 +18,7 @@ jobs:
 
   markdown-link-check:
     name: LinkCheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/pre-commit-format.yml
+++ b/.github/workflows/pre-commit-format.yml
@@ -18,7 +18,7 @@ jobs:
 
   # formatting and basic install on cpu-only machine
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
Updated GitHub Actions workflows by replacing ubuntu-20.04 with ubuntu-latest to resolve CI job failures due to deprecated environments.

## Motivation
CI checks were failing or getting cancelled because GitHub has deprecated the `ubuntu-20.04` runner. This change ensures that all CI jobs run on the supported `ubuntu-latest` environment.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).