### PR TITLE
All quantization methods

### DIFF
--- a/sllm_store/sllm_store/transformers.py
+++ b/sllm_store/sllm_store/transformers.py
@@ -287,7 +287,8 @@ def fully_parallel_load(
                         )
                     except Exception:
                         load_parameter_into_model(model, name, param)
-
+            hf_quantizer.postprocess_model(model)
+            model.hf_quantizer = hf_quantizer
         else:
             if quantization_config is not None:
                 logger.debug(
@@ -301,8 +302,6 @@ def fully_parallel_load(
     dispatch_model(
         model, device_map, skip_keys=model._skip_keys_device_placement
     )
-    hf_quantizer.postprocess_model(model)
-    model.hf_quantizer = hf_quantizer
     client = SllmStoreClient("127.0.0.1:8073")
     client.confirm_model_loaded(model_path, replica_uuid)
     model.eval()
@@ -496,7 +495,8 @@ def best_effort_load(
                         )
                     except Exception:
                         load_parameter_into_model(model, name, param)
-
+            hf_quantizer.postprocess_model(model)
+            model.hf_quantizer = hf_quantizer
         else:
             if quantization_config is not None:
                 logger.debug(

--- a/sllm_store/sllm_store/utils.py
+++ b/sllm_store/sllm_store/utils.py
@@ -19,6 +19,7 @@ from functools import reduce
 
 import torch
 from accelerate.utils import find_tied_parameters
+from transformers.quantizers.quantizers_utils import get_module_from_name
 from torch import nn
 import re
 
@@ -238,3 +239,9 @@ def to_num_bytes(value: str) -> int:
 
     bytes_value = number * unit_multipliers[unit]
     return bytes_value
+
+def load_parameter_into_model(model, param_name: str, tensor: torch.Tensor):
+    """Cast a single parameter `param_name` into the `model`, with value `tensor`."""
+    module, param_type = get_module_from_name(model, param_name)
+    # This will check potential shape mismatch if skipped before
+    module.load_state_dict({param_type: tensor}, strict=False, assign=True)

--- a/sllm_store/sllm_store/utils.py
+++ b/sllm_store/sllm_store/utils.py
@@ -240,8 +240,7 @@ def to_num_bytes(value: str) -> int:
     bytes_value = number * unit_multipliers[unit]
     return bytes_value
 
+
 def load_parameter_into_model(model, param_name: str, tensor: torch.Tensor):
-    """Cast a single parameter `param_name` into the `model`, with value `tensor`."""
     module, param_type = get_module_from_name(model, param_name)
-    # This will check potential shape mismatch if skipped before
     module.load_state_dict({param_type: tensor}, strict=False, assign=True)

--- a/tests/quantize_test/quantize_test.py
+++ b/tests/quantize_test/quantize_test.py
@@ -4,7 +4,12 @@ import unittest
 
 import pytest
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    BitsAndBytesConfig,
+    GPTQConfig,
+)
 
 from sllm_store.transformers import load_model, save_model
 
@@ -44,6 +49,17 @@ def setup_models(model_name, storage_path):
             load_in_4bit=True,
             bnb_4bit_compute_dtype=torch.float16,
             bnb_4bit_quant_type="nf4",
+        ),
+        GPTQConfig(
+            bits=4,
+            group_size=128,
+            desc_act=False,
+            sym=True,
+            true_sequential=True,
+            disable_exllama=True,
+            skip_modules=["lm_head"],
+            dataset="wikitext2",
+            tokenizer=AutoTokenizer.from_pretrained("facebook/opt-1.3b"),
         ),
     ]
 )


### PR DESCRIPTION
## Description
Added support for all quantization methods. As pre-quantization is not supported yet, all methods requiring pre-quantization are set to 'not supported' to prevent downstream issues (only bitsandbytes and gptq will be supported until pre-quantization is supported).

## Motivation
Extends 202

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [X] I have updated the tests (if applicable).
- [] I have updated the documentation (if applicable).