### PR TITLE
fix: update vllm version in quick start doc

### DIFF
--- a/docs/stable/deployment/single_machine.md
+++ b/docs/stable/deployment/single_machine.md
@@ -92,7 +92,7 @@ To install ServerlessLLM from source, follow these steps:
 
 ### vLLM Patch
 
-To use vLLM with ServerlessLLM, you must apply a patch. The patch file is located at `sllm_store/vllm_patch/sllm_load.patch` within the ServerlessLLM repository. This patch has been tested with vLLM version `0.6.6`.
+To use vLLM with ServerlessLLM, you must apply a patch. The patch file is located at `sllm_store/vllm_patch/sllm_load.patch` within the ServerlessLLM repository. This patch has been tested with vLLM version `0.9.0.1`.
 
 Apply the patch using the following script:
 

--- a/docs/stable/store/quickstart.md
+++ b/docs/stable/store/quickstart.md
@@ -114,7 +114,7 @@ ServerlessLLM integrates with vLLM to provide fast model loading capabilities. F
 
 ### Prerequisites
 
-Before using ServerlessLLM with vLLM, you need to apply a compatibility patch to your vLLM installation. This patch has been tested with vLLM version `0.6.6`.
+Before using ServerlessLLM with vLLM, you need to apply a compatibility patch to your vLLM installation. This patch has been tested with vLLM version `0.9.0.1`.
 
 ### Apply the vLLM Patch
 


### PR DESCRIPTION
## Description
Update vllm version in quick start doc

## Motivation
Clarify the vllm patch version (0.9.0.1 rather than 0.6.6).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [x] I have updated the documentation (if applicable).