### PR TITLE
feat: bitsandbytes quantization in sllm-cli

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -154,6 +154,52 @@ This file can be incomplete, and missing sections will be filled in by the defau
 }
 ```
 
+##### Example Quantization Configuration (`config.json`)
+`quantization_config` can be obtained from any configuration used in `transformers` via the `.to_json_file(filename)` function:
+
+```python
+quantization_config = BitsAndBytesConfig(load_in_8bit=True)
+quantization_config.to_json_file("quantization_config.json")
+
+```
+Then copy it into `config.json`:
+
+```json
+{
+    "model": "",
+    "backend": "transformers",
+    "num_gpus": 1,
+    "auto_scaling_config": {
+        "metric": "concurrency",
+        "target": 1,
+        "min_instances": 0,
+        "max_instances": 10,
+        "keep_alive": 0
+    },
+    "backend_config": {
+        "pretrained_model_name_or_path": "",
+        "device_map": "auto",
+        "torch_dtype": "float16",
+        "hf_model_class": "AutoModelForCausalLM",
+        "quantization_config": {
+            "_load_in_4bit": false,
+            "_load_in_8bit": true,
+            "bnb_4bit_compute_dtype": "float32",
+            "bnb_4bit_quant_storage": "uint8",
+            "bnb_4bit_quant_type": "fp4",
+            "bnb_4bit_use_double_quant": false,
+            "llm_int8_enable_fp32_cpu_offload": false,
+            "llm_int8_has_fp16_weight": false,
+            "llm_int8_skip_modules": null,
+            "llm_int8_threshold": 6.0,
+            "load_in_4bit": false,
+            "load_in_8bit": true,
+            "quant_method": "bitsandbytes"
+        }
+    }
+}
+```
+
 Below is a description of all the fields in config.json.
 
 | Field | Description |
@@ -174,6 +220,7 @@ Below is a description of all the fields in config.json.
 | backend_config.hf_model_class | HuggingFace model class. |
 | backend_config.enable_lora | Set to true to enable loading LoRA adapters during inference. |
 | backend_config.lora_adapters| A dictionary of LoRA adapters in the format `{name: path}`, where each path is a local or Hugging Face-hosted LoRA adapter directory. |
+| backend_config.quantization_config| A dictionary specifying the desired `BitsAndBytesConfig`. Can be obtained by saving a `BitsAndBytesConfig` to JSON via `BitsAndBytesConfig.to_json_file(filename). Defaults to None.|
 
 ### sllm-cli delete
 Delete deployed models by name, or delete specific LoRA adapters associated with a base model.

--- a/sllm/serve/backends/transformers_backend.py
+++ b/sllm/serve/backends/transformers_backend.py
@@ -127,6 +127,9 @@ class TransformersBackend(SllmBackend):
                 raise ValueError(
                     "hf_model_class cannot be None. Please provide a valid model class"
                 )
+            quantization_config = self.backend_config.get(
+                "quantization_config", None
+            )
 
             storage_path = os.getenv("STORAGE_PATH", "./models")
             model_path = os.path.join("transformers", self.model_name)
@@ -136,6 +139,7 @@ class TransformersBackend(SllmBackend):
                 torch_dtype=torch_dtype,
                 storage_path=storage_path,
                 hf_model_class=hf_model_class,
+                quantization_config=quantization_config,
             )
             tokenizer_path = os.path.join(
                 storage_path, "transformers", self.model_name, "tokenizer"

--- a/sllm_store/sllm_store/transformers.py
+++ b/sllm_store/sllm_store/transformers.py
@@ -20,7 +20,7 @@ import json
 import os
 import time
 import uuid
-from typing import Optional, Union
+from typing import Optional, Union, Dict, Any
 
 import torch
 from accelerate import dispatch_model, init_empty_weights
@@ -51,7 +51,7 @@ from sllm_store.utils import (
     send_module_buffers_to_device,
 )
 from torch import nn
-from transformers import AutoConfig
+from transformers import AutoConfig, BitsAndBytesConfig
 from transformers.integrations.bitsandbytes import (
     set_module_quantized_tensor_to_device,
     replace_with_bnb_linear,
@@ -140,7 +140,9 @@ def load_model(
     model_path: Optional[Union[str, os.PathLike]],
     device_map: DeviceMapType = "auto",
     torch_dtype: Optional[torch.dtype] = None,
-    quantization_config=None,
+    quantization_config: Optional[
+        Union[BitsAndBytesConfig, Dict[str, Any]]
+    ] = None,
     storage_path: Optional[str] = None,
     fully_parallel: bool = False,
     hf_model_class: str = "AutoModelForCausalLM",
@@ -171,7 +173,9 @@ def fully_parallel_load(
     hf_model_class: str,
     device_map: DeviceMapType = "auto",
     torch_dtype: Optional[torch.dtype] = None,
-    quantization_config=None,
+    quantization_config: Optional[
+        Union[BitsAndBytesConfig, Dict[str, Any]]
+    ] = None,
     storage_path: Optional[str] = None,
 ):
     if not storage_path:
@@ -227,11 +231,9 @@ def fully_parallel_load(
 
     with torch.no_grad():
         if quantization_config and torch.cuda.is_available():
-            from transformers import BitsAndBytesConfig
-
-            if not isinstance(quantization_config, BitsAndBytesConfig):
-                raise ValueError(
-                    f"Invalid config type: {type(quantization_config)}"
+            if isinstance(quantization_config, dict):
+                quantization_config = BitsAndBytesConfig.from_dict(
+                    quantization_config
                 )
 
             logger.debug(
@@ -284,7 +286,9 @@ def best_effort_load(
     hf_model_class: str,
     device_map: DeviceMapType = "auto",
     torch_dtype: Optional[torch.dtype] = None,
-    quantization_config=None,
+    quantization_config: Optional[
+        Union[BitsAndBytesConfig, Dict[str, Any]]
+    ] = None,
     storage_path: Optional[str] = None,
 ):
     client = SllmStoreClient("127.0.0.1:8073")
@@ -391,11 +395,9 @@ def best_effort_load(
 
     with torch.no_grad():
         if quantization_config and torch.cuda.is_available():
-            from transformers import BitsAndBytesConfig
-
-            if not isinstance(quantization_config, BitsAndBytesConfig):
-                raise ValueError(
-                    f"Invalid config type: {type(quantization_config)}"
+            if isinstance(quantization_config, dict):
+                quantization_config = BitsAndBytesConfig.from_dict(
+                    quantization_config
                 )
 
             logger.debug(

--- a/tests/backend_test/transformers_backend_test.py
+++ b/tests/backend_test/transformers_backend_test.py
@@ -93,12 +93,14 @@ def test_init_backend(transformers_backend, backend_config):
         torch_dtype = backend_config.get("torch_dtype", torch.float16)
         torch_dtype = getattr(torch, torch_dtype)
         hf_model_class = backend_config.get("hf_model_class", None)
+        quantization_config = backend_config.get("quantization_config", None)
         mock_load_model.assert_called_once_with(
             model_path,
             device_map=device_map,
             torch_dtype=torch_dtype,
             storage_path=storage_path,
             hf_model_class=hf_model_class,
+            quantization_config=quantization_config,
         )
 
 
@@ -117,12 +119,14 @@ def test_init_encoder_backend(encoder_backend, encoder_config):
         torch_dtype = encoder_config.get("torch_dtype", torch.float16)
         torch_dtype = getattr(torch, torch_dtype)
         hf_model_class = encoder_config.get("hf_model_class", None)
+        quantization_config = encoder_config.get("quantization_config", None)
         mock_load_model.assert_called_once_with(
             model_path,
             device_map=device_map,
             torch_dtype=torch_dtype,
             storage_path=storage_path,
             hf_model_class=hf_model_class,
+            quantization_config=quantization_config,
         )
 
 


### PR DESCRIPTION
## Description
Enables `bitsandbytes` quantization via `sllm-cli` by passing in the quantization config as part of `backend_config`.

## Motivation
Enables model quantization in `sllm-cli`

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [x] I have updated the tests (if applicable).
- [x] I have updated the documentation (if applicable).