### PR TITLE
fix+docs: sets EOS as padding token; updated default config; deleted extra quantization docs

### DIFF
--- a/docs/stable/store/quickstart.md
+++ b/docs/stable/store/quickstart.md
@@ -191,53 +191,6 @@ for output in outputs:
     print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
 ```
 
-## Quantization
-
-> Note: Quantization is currently experimental, especially on multi-GPU machines. You may encounter issues when using this feature in multi-GPU environments.
-> Note: Our current capabilities do not support pre-quantization or CPU offloading, which is why other quantization methods are not available at the moment.
-
-ServerlessLLM currently supports `bitsandbytes` quantization through `transformers`.
-
-For further information, consult the [HuggingFace Documentation for Quantization](https://huggingface.co/docs/transformers/en/main_classes/quantization)
-
-### Usage
-To use quantization, create a quantization config object with your desired settings using the `transformers` format:
-
-```python
-from transformers import BitsAndBytesConfig
-import torch
-
-# For 8-bit quantization
-quantization_config = BitsAndBytesConfig(
-    load_in_8bit=True
-)
-
-# For 4-bit quantization (NF4)
-quantization_config = BitsAndBytesConfig(
-    load_in_4bit=True,
-    bnb_4bit_quant_type="nf4"
-)
-
-# For 4-bit quantization (FP4)
-quantization_config = BitsAndBytesConfig(
-    load_in_4bit=True,
-    bnb_4bit_quant_type="fp4"
-)
-
-# Then load your model with the config
-model = load_model(
-    "facebook/opt-1.3b",
-    device_map="auto",
-    torch_dtype=torch.float16,
-    storage_path="./models/",
-    fully_parallel=True,
-    quantization_config=quantization_config,
-)
-```
-A full example can be found [here](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/sllm_store/examples/load_quantized_transformers_model.py).
-
-For users with multi-GPU setups, ensure that the number of CUDA visible devices are the same on both the store server and the user environment via `export CUDA_VISIBLE_DEVICES=<num_gpus>`.
-
 # Fine-tuning
 ServerlessLLM currently supports LoRA fine-tuning using peft through the Hugging Face Transformers PEFT.
 

--- a/sllm/cli/default_ft_config.json
+++ b/sllm/cli/default_ft_config.json
@@ -15,7 +15,9 @@
         "lora_alpha": 32,
         "lora_dropout": 0.05,
         "bias": "none",
-        "task_type": "CAUSAL_LM"
+        "task_type": "CAUSAL_LM",
+        "target_modules": ["q_proj", "v_proj"]
+
     },
     "training_config": {
         "auto_find_batch_size": true,

--- a/sllm/serve/backends/transformers_backend.py
+++ b/sllm/serve/backends/transformers_backend.py
@@ -394,6 +394,8 @@ class TransformersBackend(SllmBackend):
                 return {"error": "Model not initialized"}
 
         tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
         dataset_config = request_data.get("dataset_config")
         try:
             dataset = self._load_dataset(dataset_config, tokenizer)


### PR DESCRIPTION
## Description
- Added existence check for padding token, sets EOS as padding token if none. 
- Added "target_modules" to default config as that's required by some models, I put the one [recommended for OPT](https://github.com/huggingface/peft/blob/39ef2546d5d9b8f5f8a7016ec10657887a867041/src/peft/utils/other.py#L220)
- Deleted redundant quantization docs

## Motivation
Finetuning Llama without it resulted in this:
```
ValueError: Asking to pad but the tokenizer does not have a padding token. Please select a token to use as pad_token (tokenizer.pad_token = tokenizer.eos_token e.g.) or add a new pad token via tokenizer.add_special_tokens({'pad_token': '[PAD]'}).
```

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Documentation update

## Checklist
- [X] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).