### PR TITLE
docs: update quickstart instructions to use (or include) cli option

### DIFF
--- a/docs/stable/store/quickstart.md
+++ b/docs/stable/store/quickstart.md
@@ -54,6 +54,12 @@ ln -s /mnt/nvme/models ./models
 ```
 :::
 
+:::tip
+If you are looking for a simple way to get started, you can also perform all of the steps below
+using the `sllm-store` command-line interface. Refer to [sllm-store CLI](../../api/sllm-store-cli)
+for information on how to set up and use the CLI
+:::
+
 1. Convert a model to ServerlessLLM format and save it to a local path:
 ```python
 from sllm_store.transformers import save_model

--- a/docs/stable/store/rocm_quickstart.md
+++ b/docs/stable/store/rocm_quickstart.md
@@ -65,8 +65,8 @@ docker exec -it sllm_store_server /bin/bash
 Try to save and load a transformer model:
 
 ``` bash
-python3 examples/save_transformers_model.py --model-name "facebook/opt-1.3b" --storage-path "/models"
-python3 examples/load_transformers_model.py --model-name "facebook/opt-1.3b" --storage-path "/models"
+sllm-store save --model facebook/opt-1.3b --backend transformers --storage-path /models
+sllm-store load --model facebook/opt-1.3b --backend transformers --storage-path /models
 ```
 Expected output:
 
@@ -93,8 +93,8 @@ Hello, my dog is cute and I want to give him a good home. I have a lot of experi
 Try to save and load a model in vLLM:
 
 ``` bash
-python3 examples/save_vllm_model.py --model-name "facebook/opt-125m" --storage-path "/models"
-python3 examples/load_vllm_model.py --model-name "facebook/opt-125m" --storage-path "/models"
+sllm-store save --model facebook/opt-125m --backend vllm --storage-path /models
+sllm-store load --model facebook/opt-125m --backend vllm --storage-path /models
 ```
 Expected output:
 


### PR DESCRIPTION
## Description
Change the save and load instruction commands on rocm_quickstart.md, and suggest it on quickstart.md

## Motivation
As the CLI now supports model saving and loading, use that instead of the example script

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).