### PR TITLE
fix: logger mistake in router

### DIFF
--- a/sllm/serve/routers/roundrobin_router.py
+++ b/sllm/serve/routers/roundrobin_router.py
@@ -151,7 +151,7 @@ class RoundRobinRouter(SllmRouter):
 
         instance_allocation = self.loop.create_future()
         await self.request_queue.put(instance_allocation)
-        logger.info(f"Enqueued request for model {self.model_name}")
+        logger.info(f"Enqueued {action} request for model {self.model_name}")
 
         instance_id = await instance_allocation
         logger.info(f"{request_data}, type: {type(request_data)}")


### PR DESCRIPTION
## Description
Fix logger typo in `roundrobin_router.py`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).