### PR TITLE
feat: Implements streaming for vLLM backend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ requests==2.32.2
 serverless-llm-store
 speedtest-cli==2.1.3
 types-requests==2.31.0.20240125
+orjson==3.11.1
 uvicorn[standard]==0.23.1


### PR DESCRIPTION
Adds support for streaming chat completion responses, enhancing the user experience with faster feedback.

The changes introduce a streaming response path using Server-Sent Events when the "stream" parameter is set in the request body.  This allows the client to receive partial responses as they are generated, rather than waiting for the entire completion to be ready. It also includes necessary dependency `orjson` for json serialization.

## Description
Briefly describe your changes.

## Motivation
Explain why this change is needed and what problem it solves.
If it fixes an issue, link it (e.g., `close #123`).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).