### PR TITLE
Jysc/sllm store install fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <p align="center">
   <a href="https://serverlessllm.github.io"><b>Docs</b></a> •
   <a href="#-quick-start-90-seconds"><b>Quick Start</b></a> •
-  <a href="https://www.usenix.org/conference/osdi24/presentation/fu"><b>OSDI'24 Paper</b></a>
+  <a href="https://www.usenix.org/system/files/osdi24-fu.pdf"><b>OSDI'24 Paper</b></a>
 </p>
 
 ---
@@ -252,7 +252,7 @@ Maintained by 10+ contributors worldwide. Community contributions are welcome!
 
 ## 📄 Citation
 
-If you use ServerlessLLM in your research, please cite our [OSDI'24 paper](https://www.usenix.org/conference/osdi24/presentation/fu):
+If you use ServerlessLLM in your research, please cite our [OSDI'24 paper](https://www.usenix.org/system/files/osdi24-fu.pdf):
 
 ```bibtex
 @inproceedings{fu2024serverlessllm,

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ sllm-store save --model Qwen/Qwen3-0.6B --backend transformers
 
 ```bash
 # Start the store server first
-sllm-store start --storage-path ./models --mem-pool-size 4GB
+sllm-store start --storage-path ~/models --mem-pool-size 4GB
 ```
 
 ### Load it 6-10x Faster in Your Python Code

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -77,7 +77,7 @@ kubectl apply -f deploy/k8s/configmap.yaml -f deploy/k8s/job.yaml
 | `--num-replicas` | `30` | Number of iterations |
 | `--mem-pool-size` | `32GB` | sllm-store memory pool |
 | `--benchmark-type` | `random` | Test type (random/cached) |
-| `--storage-path` | `./models` | Model storage directory |
+| `--storage-path` | `~/models` | Model storage directory |
 | `--results-path` | `./results` | Results output directory |
 | `--generate-plots` | `false` | Generate visualizations |
 
@@ -89,7 +89,7 @@ Requires `sllm-store` to be installed. The script automatically handles starting
 
 ```bash
 # Ensure models directory exists
-mkdir -p ./models
+mkdir -p ~/models
 
 # Run benchmark (starts sllm-store automatically)
 ./run-benchmark.sh \

--- a/benchmarks/run-benchmark.sh
+++ b/benchmarks/run-benchmark.sh
@@ -16,7 +16,7 @@ OPTIONS:
   -m, --model-name NAME        Model to benchmark (default: facebook/opt-6.7b)
   -n, --num-replicas N         Number of test replicas (default: 30)
   -p, --mem-pool-size SIZE     Memory pool size (default: 32GB)
-  -s, --storage-path PATH      Model storage directory (default: ./models)
+  -s, --storage-path PATH      Model storage directory (default: ~/models)
   -r, --results-path PATH      Results output directory (default: ./results)
   -t, --benchmark-type TYPE    Test type: random|cached (default: random)
       --generate-plots         Generate visualization plots
@@ -91,7 +91,7 @@ done
 MODEL_NAME="${CLI_MODEL_NAME:-${MODEL_NAME:-facebook/opt-6.7b}}"
 NUM_REPLICAS="${CLI_NUM_REPLICAS:-${NUM_REPLICAS:-30}}"
 MEM_POOL_SIZE="${CLI_MEM_POOL_SIZE:-${MEM_POOL_SIZE:-32GB}}"
-STORAGE_PATH="${CLI_STORAGE_PATH:-${STORAGE_PATH:-./models}}"
+STORAGE_PATH="${CLI_STORAGE_PATH:-${STORAGE_PATH:-$HOME/models}}"
 RESULTS_PATH="${CLI_RESULTS_PATH:-${RESULTS_PATH:-./results}}"
 BENCHMARK_TYPE="${CLI_BENCHMARK_TYPE:-${BENCHMARK_TYPE:-random}}"
 GENERATE_PLOTS="${CLI_GENERATE_PLOTS:-${GENERATE_PLOTS:-false}}"

--- a/docs/api/sllm-store-cli.md
+++ b/docs/api/sllm-store-cli.md
@@ -33,7 +33,7 @@ pip install serverless-llm-store
 ```
 
 ## Example Workflow
-1. Firstly, start the ServerlessLLM Store server. By default, it uses ./models as the storage path.
+1. Firstly, start the ServerlessLLM Store server. By default, it uses ~/models as the storage path.
 Launch the checkpoint store server in a separate process:
 ``` bash
 # 'mem_pool_size' is the maximum size of the memory pool in GB. It should be larger than the model size.

--- a/docs/deployment/single_machine.md
+++ b/docs/deployment/single_machine.md
@@ -132,7 +132,7 @@ ray start --address=0.0.0.0:6379 --num-cpus=4 --num-gpus=1 \
 
 ### 2. Start the ServerlessLLM Store Server
 
-Next, start the ServerlessLLM Store server. By default, it uses `./models` as the storage path.
+Next, start the ServerlessLLM Store server. By default, it uses `~/models` as the storage path.
 
 Open a new terminal and run:
 

--- a/docs/store/quickstart.md
+++ b/docs/store/quickstart.md
@@ -50,7 +50,7 @@ We highly recommend using a fast storage device (e.g., NVMe SSD) to store the mo
 For example, create a directory `models` on the NVMe SSD and link it to the local path.
 ```bash
 mkdir -p /mnt/nvme/models   # Replace '/mnt/nvme' with your NVMe SSD path.
-ln -s /mnt/nvme/models ./models
+ln -s /mnt/nvme/models ~/models
 ```
 :::
 
@@ -63,8 +63,8 @@ import torch
 from transformers import AutoModelForCausalLM
 model = AutoModelForCausalLM.from_pretrained('facebook/opt-1.3b', torch_dtype=torch.float16)
 
-# Replace './models' with your local path.
-save_model(model, './models/facebook/opt-1.3b')
+# Replace '~/models' with your local path.
+save_model(model, '~/models/facebook/opt-1.3b')
 ```
 
 2. Launch the checkpoint store server in a separate process:
@@ -94,7 +94,7 @@ for i in range(num_gpus):
     torch.cuda.synchronize()
 
 start = time.time()
-model = load_model("facebook/opt-1.3b", device_map="auto", torch_dtype=torch.float16, storage_path="./models/", fully_parallel=True)
+model = load_model("facebook/opt-1.3b", device_map="auto", torch_dtype=torch.float16, storage_path=os.path.expanduser("~/models"), fully_parallel=True)
 # Please note the loading time depends on the model size and the hardware bandwidth.
 print(f"Model loading time: {time.time() - start:.2f}s")
 
@@ -164,7 +164,7 @@ from vllm import LLM, SamplingParams
 
 import os
 
-storage_path = os.getenv("STORAGE_PATH", "./models")
+storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
 model_name = "facebook/opt-1.3b"
 model_path = os.path.join(storage_path, model_name)
 
@@ -211,8 +211,8 @@ from sllm_store.transformers import save_lora
 from transformers import AutoModelForCausalLM
 model = AutoModelForCausalLM.from_pretrained('facebook/opt-1.3b', torch_dtype=torch.float16) -->
 
-# Replace './models' with your local path.
-save_lora(adapter, './models/facebook/opt-1.3b')
+# Replace '~/models' with your local path.
+save_lora(adapter, '~/models/facebook/opt-1.3b')
 ```
 
 2. Launch the checkpoint store server in a separate process:
@@ -227,9 +227,9 @@ import time
 import torch
 from sllm_store.transformers import load_model, load_lora
 
-model = load_model("facebook/opt-1.3b", device_map="auto", torch_dtype=torch.float16, storage_path="./models/", fully_parallel=True)
+model = load_model("facebook/opt-1.3b", device_map="auto", torch_dtype=torch.float16, storage_path=os.path.expanduser("~/models"), fully_parallel=True)
 
-model = load_lora("facebook/opt-1.3b", adapter_name="demo_lora", adapter_path="ft_facebook/opt-1.3b_adapter1", device_map="auto", torch_dtype=torch.float16, storage_path="./models/")
+model = load_lora("facebook/opt-1.3b", adapter_name="demo_lora", adapter_path="ft_facebook/opt-1.3b_adapter1", device_map="auto", torch_dtype=torch.float16, storage_path=os.path.expanduser("~/models"))
 
 # Please note the loading time depends on the base model size and the hardware bandwidth.
 print(f"Model loading time: {time.time() - start:.2f}s")

--- a/examples/windows_wsl/README.md
+++ b/examples/windows_wsl/README.md
@@ -135,10 +135,10 @@ Once installed, refer to the [Quick Start Guide](https://serverlessllm.github.io
 
 If you encounter errors such as:
 ```bash
-No such file or directory: `./models/vllm`
+No such file or directory: `~/models/vllm`
 ```
 
-This usually indicates a permission or accessibility issue with the `./models` folder. Resolve this by:
+This usually indicates a permission or accessibility issue with the `~/models` folder. Resolve this by:
 
 1. Checking the folder status:
 ```bash
@@ -150,6 +150,6 @@ If the folder appears in red, it is inaccessible.
 2. Deleting and recreating the folder:
 ```bash
 # Run this command in the WSL terminal
-sudo rm -rf ./models
-mkdir ./models
+sudo rm -rf ~/models
+mkdir ~/models
 ```

--- a/sllm/backends/transformers_backend.py
+++ b/sllm/backends/transformers_backend.py
@@ -131,7 +131,9 @@ class TransformersBackend(SllmBackend):
                 "quantization_config", None
             )
 
-            storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
+            storage_path = os.getenv(
+                "STORAGE_PATH", os.path.expanduser("~/models")
+            )
             model_path = os.path.join("transformers", self.model_name)
             self.model = load_model(
                 model_path,

--- a/sllm/backends/transformers_backend.py
+++ b/sllm/backends/transformers_backend.py
@@ -131,7 +131,7 @@ class TransformersBackend(SllmBackend):
                 "quantization_config", None
             )
 
-            storage_path = os.getenv("STORAGE_PATH", "./models")
+            storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
             model_path = os.path.join("transformers", self.model_name)
             self.model = load_model(
                 model_path,
@@ -343,7 +343,7 @@ class TransformersBackend(SllmBackend):
             return
 
         lora_path = os.path.join("transformers", lora_path)
-        storage_path = os.getenv("STORAGE_PATH", "./models")
+        storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
         device_map = self.backend_config.get("device_map", "auto")
         torch_dtype = self.backend_config.get("torch_dtype", torch.float16)
         torch_dtype = getattr(torch, torch_dtype)

--- a/sllm/backends/vllm_backend.py
+++ b/sllm/backends/vllm_backend.py
@@ -176,7 +176,9 @@ class VllmBackend(SllmBackend):
                 "pretrained_model_name_or_path"
             )
         else:
-            storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
+            storage_path = os.getenv(
+                "STORAGE_PATH", os.path.expanduser("~/models")
+            )
             model_path = os.path.join(storage_path, "vllm", model)
             filtered_engine_config["model"] = model_path
             filtered_engine_config["load_format"] = "serverless_llm"

--- a/sllm/backends/vllm_backend.py
+++ b/sllm/backends/vllm_backend.py
@@ -176,7 +176,7 @@ class VllmBackend(SllmBackend):
                 "pretrained_model_name_or_path"
             )
         else:
-            storage_path = os.getenv("STORAGE_PATH", "./models")
+            storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
             model_path = os.path.join(storage_path, "vllm", model)
             filtered_engine_config["model"] = model_path
             filtered_engine_config["load_format"] = "serverless_llm"

--- a/sllm/ft_backends/peft_lora_backend.py
+++ b/sllm/ft_backends/peft_lora_backend.py
@@ -145,7 +145,7 @@ class PeftLoraBackend(SllmFineTuningBackend):
             )
             logger.info(f"Using model class: {hf_model_class}")
 
-            storage_path = os.getenv("STORAGE_PATH", "./models")
+            storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
             model_path = os.path.join("transformers", self.model_name)
 
             self.model = load_model(
@@ -276,7 +276,7 @@ class PeftLoraBackend(SllmFineTuningBackend):
 
         training_config = request_data.get("training_config")
         logger.info(f"Creating training config: {training_config}")
-        storage_path = os.getenv("STORAGE_PATH", "./models")
+        storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
         output_dir = request_data.get(
             "output_dir", f"ft_{self.model_name}_adapter"
         )

--- a/sllm/ft_backends/peft_lora_backend.py
+++ b/sllm/ft_backends/peft_lora_backend.py
@@ -145,7 +145,9 @@ class PeftLoraBackend(SllmFineTuningBackend):
             )
             logger.info(f"Using model class: {hf_model_class}")
 
-            storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
+            storage_path = os.getenv(
+                "STORAGE_PATH", os.path.expanduser("~/models")
+            )
             model_path = os.path.join("transformers", self.model_name)
 
             self.model = load_model(

--- a/sllm/model_downloader.py
+++ b/sllm/model_downloader.py
@@ -45,7 +45,7 @@ def download_transformers_model(
     torch_dtype: str,
     hf_model_class: str,
 ) -> bool:
-    storage_path = os.getenv("STORAGE_PATH", "./models")
+    storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
     model_path = os.path.join(storage_path, "transformers", model_name)
     tokenizer_path = os.path.join(
         storage_path, "transformers", model_name, "tokenizer"
@@ -100,7 +100,7 @@ def download_lora_adapter(
     hf_model_class: str,
     torch_dtype: str,
 ) -> bool:
-    storage_path = os.getenv("STORAGE_PATH", "./models")
+    storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
     adapter_path = os.path.join(
         storage_path, "transformers", adapter_name_or_path
     )
@@ -174,7 +174,7 @@ class VllmModelDownloader:
         from vllm import LLM
 
         # set the storage path
-        storage_path = os.getenv("STORAGE_PATH", "./models")
+        storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
         model_path = os.path.join(storage_path, "vllm", model_name)
         if os.path.exists(model_path):
             logger.info(f"{model_path} already exists")

--- a/sllm_store/README.md
+++ b/sllm_store/README.md
@@ -158,7 +158,7 @@ ServerlessLLM Store is the storage layer of [ServerlessLLM](../README.md), enabl
 
 ## 📄 Citation
 
-If you use ServerlessLLM Store in your research, please cite our [OSDI'24 paper](https://www.usenix.org/conference/osdi24/presentation/fu):
+If you use ServerlessLLM Store in your research, please cite our [OSDI'24 paper](https://www.usenix.org/system/files/osdi24-fu.pdf):
 
 ```bibtex
 @inproceedings{fu2024serverlessllm,

--- a/sllm_store/README.md
+++ b/sllm_store/README.md
@@ -100,7 +100,7 @@ sllm-store save --model Qwen/Qwen3-0.6B --backend transformers
 
 ```bash
 sllm-store start \
-  --storage-path ./models \
+  --storage-path ~/models \
   --mem-pool-size 4GB \
   --num-threads 4
 ```

--- a/sllm_store/examples/load_lora_adapter.py
+++ b/sllm_store/examples/load_lora_adapter.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import time
 
 import torch

--- a/sllm_store/examples/load_lora_adapter.py
+++ b/sllm_store/examples/load_lora_adapter.py
@@ -20,7 +20,7 @@ parser.add_argument(
 parser.add_argument(
     "--storage-path",
     type=str,
-    default="./models",
+    default=os.path.expanduser("~/models"),
     help="Local path stored the model.",
 )
 

--- a/sllm_store/examples/load_quantized_transformers_model.py
+++ b/sllm_store/examples/load_quantized_transformers_model.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import time
 
 import torch

--- a/sllm_store/examples/load_quantized_transformers_model.py
+++ b/sllm_store/examples/load_quantized_transformers_model.py
@@ -13,7 +13,7 @@ parser.add_argument(
 parser.add_argument(
     "--storage-path",
     type=str,
-    default="./models",
+    default=os.path.expanduser("~/models"),
     help="Local path stored the model.",
 )
 

--- a/sllm_store/examples/load_transformers_model.py
+++ b/sllm_store/examples/load_transformers_model.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import time
 
 import torch

--- a/sllm_store/examples/load_transformers_model.py
+++ b/sllm_store/examples/load_transformers_model.py
@@ -14,7 +14,7 @@ parser.add_argument(
 parser.add_argument(
     "--storage-path",
     type=str,
-    default="./models",
+    default=os.path.expanduser("~/models"),
     help="Local path stored the model.",
 )
 

--- a/sllm_store/examples/load_vllm_model.py
+++ b/sllm_store/examples/load_vllm_model.py
@@ -15,7 +15,7 @@ parser.add_argument(
 parser.add_argument(
     "--storage-path",
     type=str,
-    default="./models",
+    default=os.path.expanduser("~/models"),
     help="Local path to save the model.",
 )
 

--- a/sllm_store/examples/save_lora_adapter.py
+++ b/sllm_store/examples/save_lora_adapter.py
@@ -26,7 +26,7 @@ parser.add_argument(
 parser.add_argument(
     "--storage-path",
     type=str,
-    default="./models",
+    default=os.path.expanduser("~/models"),
     help="Local path to save the model.",
 )
 

--- a/sllm_store/examples/save_transformers_model.py
+++ b/sllm_store/examples/save_transformers_model.py
@@ -18,7 +18,7 @@ parser.add_argument(
 parser.add_argument(
     "--storage-path",
     type=str,
-    default="./models",
+    default=os.path.expanduser("~/models"),
     help="Local path to save the model.",
 )
 

--- a/sllm_store/examples/save_vllm_model.py
+++ b/sllm_store/examples/save_vllm_model.py
@@ -26,7 +26,9 @@ class VllmModelDownloader:
         from vllm import LLM
 
         # set the model storage path
-        storage_path = os.getenv("STORAGE_PATH", storage_path) or os.path.expanduser("~/models")
+        storage_path = os.getenv(
+            "STORAGE_PATH", storage_path
+        ) or os.path.expanduser("~/models")
 
         def _run_writer(input_dir, model_name):
             # load models from the input directory

--- a/sllm_store/examples/save_vllm_model.py
+++ b/sllm_store/examples/save_vllm_model.py
@@ -13,7 +13,7 @@ class VllmModelDownloader:
         model_name: str,
         torch_dtype: str,
         tensor_parallel_size: int = 1,
-        storage_path: str = "./models",
+        storage_path: str = os.path.expanduser("~/models"),
         local_model_path: Optional[str] = None,
         pattern: Optional[str] = None,
         max_size: Optional[int] = None,
@@ -26,7 +26,7 @@ class VllmModelDownloader:
         from vllm import LLM
 
         # set the model storage path
-        storage_path = os.getenv("STORAGE_PATH", storage_path)
+        storage_path = os.getenv("STORAGE_PATH", storage_path) or os.path.expanduser("~/models")
 
         def _run_writer(input_dir, model_name):
             # load models from the input directory
@@ -108,7 +108,7 @@ parser.add_argument(
 parser.add_argument(
     "--storage-path",
     type=str,
-    default="./models",
+    default=os.path.expanduser("~/models"),
     help="Local path to save the model.",
 )
 parser.add_argument(

--- a/sllm_store/requirements-build.txt
+++ b/sllm_store/requirements-build.txt
@@ -1,7 +1,7 @@
 cmake>=3.20,<4.0.0
 ninja
 numpy
-peft==0.15.2
+peft>=0.16.0
 setuptools
-torch==2.9.0
+torch==2.9.1
 wheel

--- a/sllm_store/requirements-vllm.txt
+++ b/sllm_store/requirements-vllm.txt
@@ -1,0 +1,7 @@
+accelerate>=1.7.0
+attrs>=22.2.0
+bitsandbytes==0.46.0
+click==8.1.7
+peft>=0.16.0
+pillow>=10.3.0
+vllm

--- a/sllm_store/requirements.txt
+++ b/sllm_store/requirements.txt
@@ -1,8 +1,13 @@
 accelerate>=1.7.0
+attrs>=22.2.0
 bitsandbytes==0.46.0
 click==8.1.7
-grpcio==1.72.1
-grpcio-tools==1.64.0
+grpcio==1.76.0
+grpcio-tools==1.76.0
+httpx>=0.27.0
 peft>=0.16.0
+pillow>=10.3.0
+pydantic>=2.7.0
 torch>=2.7.0
 transformers>=4.52.4
+uvicorn[standard]>=0.15.0

--- a/sllm_store/setup.py
+++ b/sllm_store/setup.py
@@ -121,6 +121,8 @@ install_requires = fetch_requirements("requirements.txt")
 
 extras = {}
 
+extras["vllm"] = fetch_requirements("requirements-vllm.txt")
+
 extras["test"] = [
     "pytest",
     "accelerate>=0.27.2",

--- a/sllm_store/setup.py
+++ b/sllm_store/setup.py
@@ -121,7 +121,10 @@ install_requires = fetch_requirements("requirements.txt")
 
 extras = {}
 
-extras["vllm"] = fetch_requirements("requirements-vllm.txt")
+extras["vllm"] = [
+    "vllm",
+    "pillow>=10.3.0",
+]
 
 extras["test"] = [
     "pytest",

--- a/sllm_store/sllm_store/cli.py
+++ b/sllm_store/sllm_store/cli.py
@@ -341,7 +341,7 @@ def save(
     "--storage-path",
     type=str,
     default=None,
-    help="Local path where model is saved (default: $STORAGE_PATH or ~/models/)",  # noqa: E501
+    help="Local path where model is saved (default: $SLLM_STORAGE_PATH or ~/models/)",  # noqa: E501
 )
 def load(
     model_name,

--- a/sllm_store/sllm_store/cli.py
+++ b/sllm_store/sllm_store/cli.py
@@ -272,7 +272,7 @@ def save(
     try:
         if backend == "vllm":
             downloader = VllmModelDownloader()
-            storage_path = storage_path + "/" + "vllm"
+            storage_path = os.path.join(storage_path, "vllm")
             downloader.download_vllm_model(
                 model_name,
                 "float16",

--- a/sllm_store/sllm_store/cli.py
+++ b/sllm_store/sllm_store/cli.py
@@ -44,12 +44,12 @@ def resolve_storage_path(cli_path: Optional[str]) -> str:
     """
     Resolve storage path with priority:
     1. CLI specified --storage-path (highest priority)
-    2. Environment variable SLLM_STORAGE_PATH
+    2. Environment variable STORAGE_PATH
     3. Default ~/models/ (lowest priority)
     """
     if cli_path is not None:
         return os.path.expanduser(cli_path)
-    env_path = os.getenv("SLLM_STORAGE_PATH")
+    env_path = os.getenv("STORAGE_PATH")
     if env_path:
         return os.path.expanduser(env_path)
     return os.path.expanduser("~/models/")
@@ -168,7 +168,7 @@ def cli():
 @click.option(
     "--storage-path",
     default=None,
-    help="Storage path (default: $SLLM_STORAGE_PATH or ~/models/)",
+    help="Storage path (default: $STORAGE_PATH or ~/models/)",
 )
 @click.option("--num-thread", default=4, help="Number of I/O threads")
 @click.option(
@@ -246,7 +246,7 @@ def start(
 @click.option(
     "--storage-path",
     default=None,
-    help="Local path to save the model (default: $SLLM_STORAGE_PATH or ~/models/)",  # noqa: E501
+    help="Local path to save the model (default: $STORAGE_PATH or ~/models/)",  # noqa: E501
 )
 def save(
     model_name,
@@ -341,7 +341,7 @@ def save(
     "--storage-path",
     type=str,
     default=None,
-    help="Local path where model is saved (default: $SLLM_STORAGE_PATH or ~/models/)",  # noqa: E501
+    help="Local path where model is saved (default: $STORAGE_PATH or ~/models/)",  # noqa: E501
 )
 def load(
     model_name,
@@ -380,7 +380,7 @@ def load(
         if backend == "vllm":
             from vllm import LLM
 
-            model_full_path = os.path.join(storage_path, model_name)
+            model_full_path = os.path.join(storage_path, "vllm", model_name)
             llm = LLM(
                 model=model_full_path,
                 load_format="serverless_llm",

--- a/sllm_store/sllm_store/torch.py
+++ b/sllm_store/sllm_store/torch.py
@@ -106,7 +106,7 @@ def load_dict_non_blocking(
         raise ValueError(f"Failed to load model {model_path} into CPU")
 
     if not storage_path:
-        storage_path = os.getenv("STORAGE_PATH", "./models")
+        storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
     with open(
         os.path.join(storage_path, model_path, "tensor_index.json"), "r"
     ) as f:

--- a/sllm_store/sllm_store/transformers.py
+++ b/sllm_store/sllm_store/transformers.py
@@ -179,7 +179,7 @@ def fully_parallel_load(
     storage_path: Optional[str] = None,
 ):
     if not storage_path:
-        storage_path = os.getenv("STORAGE_PATH", "./models")
+        storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
 
     start = time.time()
     device_map = _transform_device_map_to_dict(device_map)
@@ -286,7 +286,7 @@ def best_effort_load(
         raise ValueError("CPU is not supported in device_map.")
 
     if not storage_path:
-        storage_path = os.getenv("STORAGE_PATH", "./models")
+        storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
     start = time.time()
     config = AutoConfig.from_pretrained(
         f"{os.path.join(storage_path, model_path)}", trust_remote_code=True
@@ -416,7 +416,7 @@ def load_lora(
     torch_dtype: Optional[torch.dtype] = None,
 ):
     if not storage_path:
-        storage_path = os.getenv("STORAGE_PATH", "./models")
+        storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
 
     config_path = os.path.join(
         storage_path, adapter_path, "adapter_config.json"

--- a/sllm_store/tests/python/test_cli.py
+++ b/sllm_store/tests/python/test_cli.py
@@ -12,7 +12,7 @@ TEST_ADAPTER_MODEL = (
     "jeanlucmarsh/opt-125m-pattern-based_finetuning_with_lora-mnli-mm-d3_fs2"
 )
 TEST_DIRECTORY_SAVE = "./test_save_models"
-TEST_DIRECTORY_LOAD = "./models"
+TEST_DIRECTORY_LOAD = os.path.expanduser("~/models")
 
 
 class TestCliCommands(unittest.TestCase):
@@ -283,7 +283,7 @@ class TestCliCommands(unittest.TestCase):
             0,
             f"Command failed with output: {result.output}",
         )
-        expected_folder = Path("./models") / TEST_MODEL_TRANSFORMERS
+        expected_folder = Path(os.path.expanduser("~/models")) / TEST_MODEL_TRANSFORMERS
         self.assertTrue(
             expected_folder.is_dir(),
             f"Folder does not exist: {expected_folder}",

--- a/sllm_store/tests/python/test_cli.py
+++ b/sllm_store/tests/python/test_cli.py
@@ -283,7 +283,9 @@ class TestCliCommands(unittest.TestCase):
             0,
             f"Command failed with output: {result.output}",
         )
-        expected_folder = Path(os.path.expanduser("~/models")) / TEST_MODEL_TRANSFORMERS
+        expected_folder = (
+            Path(os.path.expanduser("~/models")) / TEST_MODEL_TRANSFORMERS
+        )
         self.assertTrue(
             expected_folder.is_dir(),
             f"Folder does not exist: {expected_folder}",

--- a/sllm_store/vllm_patch/sllm_load.patch
+++ b/sllm_store/vllm_patch/sllm_load.patch
@@ -118,7 +118,7 @@ index 000000000..c65b46989
 +        
 +        # vLLM needs a local model path to read model config but
 +        # ServerlessLLM Store requires a global model path as the model ID
-+        storage_path = os.getenv("STORAGE_PATH", "./models")
++        storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
 +        model_path = remove_prefix(local_model_path, storage_path)
 +        
 +        with set_default_torch_dtype(vllm_config.model_config.dtype):

--- a/tests/backend_test/peft_lora_backend_test.py
+++ b/tests/backend_test/peft_lora_backend_test.py
@@ -180,7 +180,10 @@ def test_init_backend_with_local_tokenizer(
 
     mock_tokenizer_from_pretrained.assert_called_once_with(
         os.path.join(
-            os.path.expanduser("~/models"), "transformers", "facebook/opt-125m", "tokenizer"
+            os.path.expanduser("~/models"),
+            "transformers",
+            "facebook/opt-125m",
+            "tokenizer",
         )
     )
 

--- a/tests/backend_test/peft_lora_backend_test.py
+++ b/tests/backend_test/peft_lora_backend_test.py
@@ -156,7 +156,7 @@ def test_init_backend_success(
     mock_load_model.assert_called_once()
     call_args = mock_load_model.call_args
     assert call_args[0][0] == os.path.join(
-        "./models", "transformers", "facebook/opt-125m"
+        os.path.expanduser("~/models"), "transformers", "facebook/opt-125m"
     )
     assert call_args[1]["device_map"] == "auto"
     assert call_args[1]["torch_dtype"] == torch.float16
@@ -180,7 +180,7 @@ def test_init_backend_with_local_tokenizer(
 
     mock_tokenizer_from_pretrained.assert_called_once_with(
         os.path.join(
-            "./models", "transformers", "facebook/opt-125m", "tokenizer"
+            os.path.expanduser("~/models"), "transformers", "facebook/opt-125m", "tokenizer"
         )
     )
 

--- a/tests/backend_test/transformers_backend_test.py
+++ b/tests/backend_test/transformers_backend_test.py
@@ -84,7 +84,7 @@ def test_init_backend(transformers_backend, backend_config):
     ) as mock_load_model:
         transformers_backend.init_backend()
         mock_load_model.assert_called_once()
-        storage_path = os.getenv("STORAGE_PATH", "./models")
+        storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
         model_path = os.path.join(
             "transformers",
             backend_config["pretrained_model_name_or_path"],
@@ -110,7 +110,7 @@ def test_init_encoder_backend(encoder_backend, encoder_config):
     ) as mock_load_model:
         encoder_backend.init_backend()
         mock_load_model.assert_called_once()
-        storage_path = os.getenv("STORAGE_PATH", "./models")
+        storage_path = os.getenv("STORAGE_PATH", os.path.expanduser("~/models"))
         model_path = os.path.join(
             "transformers",
             encoder_config["pretrained_model_name_or_path"],


### PR DESCRIPTION
## Description
Fixed storage path resolution and installation conflict issues.

Storage path now prioritizes `--storage-path` flag, then falls back to `SLLM_STORAGE_PATH` environment variable.
Resolved dependency conflicts by isolating vLLM in a separate environment; install via `pip install .[vllm]` or `pip install serverless-llm-store[vllm]`

## Motivation
Close #313 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/ServerlessLLM/ServerlessLLM/blob/main/CONTRIBUTING.md) guide.
- [x] I have updated the tests (if applicable).
- [x] I have updated the documentation (if applicable).