### PR TITLE
feat(batch): add OpenAI-compatible batch API with auto-TP and model grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,20 @@ output = model.generate(**inputs)
 
 ---
 
+## 🖥️ Different Hardware / CUDA Version?
+
+`requirements.txt` pins the torch stack to **CUDA 12.8** and the build targets **sm_86** (A5000). For other setups, change two things before `pip install -r requirements.txt`:
+
+1. **CUDA wheel index** — in `requirements.txt`, replace `cu128` with your CUDA version (e.g. `cu121`, `cu124`), and update the pinned `torch` / `torchvision` / `torchaudio` / `nvidia-nccl-cu12` versions to a compatible set from [pytorch.org](https://pytorch.org/get-started/locally/).
+2. **GPU compute capability** — before building `sllm_store`, export the arch list matching your GPU (e.g. `8.0` for A100, `8.9` for L40/4090, `9.0` for H100):
+   ```bash
+   export TORCH_CUDA_ARCH_LIST="8.0"
+   ```
+
+Everything else (transformers, vllm, cmake, etc.) is hardware-agnostic.
+
+---
+
 ## 🎯 Key Features
 
 ### ⚡ Ultra-Fast Model Loading

--- a/requirements-vllm.txt
+++ b/requirements-vllm.txt
@@ -3,8 +3,6 @@ aiohttp
 datasets>=3.6.0
 GPUtil==1.4.0
 peft>=0.15.2
-serverless-llm-store
 speedtest-cli==2.1.3
-torch>=2.7.0
-transformers>=4.52.4
+transformers>=4.55,<5.0
 vllm==0.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-# ServerlessLLM v1-beta dependencies
+# Pytorch wheels built for CUDA 12.8. Change for other CUDA versions.
+--index-url https://download.pytorch.org/whl/cu128
+--extra-index-url https://pypi.org/simple
+
+# ServerlessLLM v1-beta runtime deps
 aiohttp
 fastapi==0.115.12
 GPUtil==1.4.0
@@ -6,7 +10,20 @@ pydantic==2.11.5
 pydantic_core==2.33.2
 pylet>=0.3.0
 requests==2.32.2
-serverless-llm-store
 speedtest-cli==2.1.3
 types-requests==2.31.0.20240125
 uvicorn[standard]==0.23.1
+
+# Torch stack pinned for CUDA 12.8 + sm_86 (A5000). Change for other GPUs.
+torch==2.9.1
+torchvision==0.24.1
+torchaudio==2.9.1
+nvidia-nccl-cu12==2.27.5
+
+# vllm 0.11.2 imports DeepseekV2Config, added in transformers 4.55.
+transformers>=4.55,<5.0
+
+# sllm_store build deps (pre-installed for --no-build-isolation).
+cmake>=3.20,<4.0.0
+ninja
+numpy

--- a/scripts/start_cluster_batch.sh
+++ b/scripts/start_cluster_batch.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -e
+
+# === Start Cluster with Batch Processing ENABLED ===
+# This script starts the full ServerlessLLM stack with the Batch Scheduler active.
+# Use this for testing batch jobs, DAG dependencies, and scheduler optimizations.
+
+# MPS Workaround (User specific)
+export CUDA_MPS_PIPE_DIRECTORY=/tmp/no_mps_vllm
+
+# Fix: CUDA toolkit stub shadows real driver (since CUDA toolkit update 2026-03-12)
+export LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}
+
+# Activate virtual environment explicitly
+source .venv_new/bin/activate
+
+# Configuration
+PYTHON=.venv_new/bin/python
+PYLET_BIN=.venv_new/bin/pylet
+SLLM_BIN=.venv_new/bin/sllm
+PORT=8343
+
+echo "=== GPU Configuration ==="
+if [ -n "$CUDA_VISIBLE_DEVICES" ]; then
+    export CUDA_VISIBLE_DEVICES
+    echo "CUDA_VISIBLE_DEVICES: $CUDA_VISIBLE_DEVICES"
+else
+    echo "CUDA_VISIBLE_DEVICES: Not Set (Using all available GPUs)"
+fi
+
+echo "Visible GPUs (as seen by PyTorch):"
+$PYTHON -c "import torch; print(f'Count: {torch.cuda.device_count()}'); print([torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())])" || echo "Failed to query PyTorch."
+echo "========================="
+
+# Paths (using distinct directories for isolation)
+MODELS_DIR="./models_batch"
+DB_PATH="./state_batch.db"
+
+# Cleanup
+echo "Cleaning up previous run..."
+pkill -f "pylet start" || true
+pkill -f "sllm start" || true
+pkill -f "sllm-store" || true
+sleep 2
+
+mkdir -p $MODELS_DIR
+rm -f ${DB_PATH}*
+rm -f ~/.pylet/pylet.db*
+
+echo "=== 1. Starting Pylet Head (Cluster Manager) ==="
+$PYLET_BIN start > pylet_head_batch.log 2>&1 &
+echo "Pylet Head PID: $!"
+sleep 2
+
+# Auto-detect GPU count from CUDA_VISIBLE_DEVICES
+if [ -n "$CUDA_VISIBLE_DEVICES" ]; then
+    GPU_COUNT=$(echo "$CUDA_VISIBLE_DEVICES" | tr ',' '\n' | wc -l)
+else
+    GPU_COUNT=$($PYTHON -c "import torch; print(torch.cuda.device_count())" 2>/dev/null || echo 1)
+fi
+echo "=== 2. Starting Pylet Worker ($GPU_COUNT GPUs) ==="
+# Connects to localhost:8000
+# We explicitly pass the env var again to be absolutely sure
+CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES $PYLET_BIN start --head localhost:8000 --gpu-units $GPU_COUNT > pylet_worker_batch.log 2>&1 &
+echo "Pylet Worker PID: $!"
+sleep 2
+
+echo "=== 3. Starting SLLM Head (Gateway + Router + Batch Scheduler) ==="
+# Explicitly enable batch scheduler
+export ENABLE_BATCH_SCHEDULER=true
+# Pass pinned memory pool size to sllm-store (80 GB fits Qwen2.5-32B-Instruct ~64 GB)
+export SLLM_STORE_MEM_POOL_SIZE=80GB
+
+CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES $SLLM_BIN start \
+    --host 0.0.0.0 \
+    --port $PORT \
+    --pylet-endpoint http://localhost:8000 \
+    --database-path "$DB_PATH" \
+    --storage-path "$MODELS_DIR" > sllm_head_batch.log 2>&1 &
+echo "SLLM Head PID: $!"
+
+echo ""
+echo "============================================================"
+echo "Cluster Started (Batch Mode)"
+echo "API Endpoint: http://localhost:$PORT"
+echo "Batch Endpoint: http://localhost:$PORT/v1/batches"
+echo "Logs: sllm_head_batch.log"
+echo "============================================================"
+echo "Press Ctrl+C to stop the cluster."
+
+# === Example Usage (Run in another terminal) ===
+echo ""
+echo "=== To Submit a 10-Task Batch Job (Qwen 0.6B & 7B) ==="
+echo "Run the following command in another terminal:"
+echo ""
+echo "curl -X POST http://localhost:8343/v1/batches \\"
+echo "  -H \"Content-Type: application/json\" \\"
+echo "  -d '{"
+echo "    \"tasks\": ["
+echo "      {\"custom_id\": \"task-1-small\", \"method\": \"POST\", \"url\": \"/v1/chat/completions\", \"body\": {\"model\": \"Qwen/Qwen3-0.6B\", \"messages\": [{\"role\": \"user\", \"content\": \"1+1=?\"}], \"max_tokens\": 20}},"
+echo "      {\"custom_id\": \"task-2-small\", \"method\": \"POST\", \"url\": \"/v1/chat/completions\", \"body\": {\"model\": \"Qwen/Qwen3-0.6B\", \"messages\": [{\"role\": \"user\", \"content\": \"Name a color.\"}], \"max_tokens\": 20}},"
+echo "      {\"custom_id\": \"task-3-small\", \"method\": \"POST\", \"url\": \"/v1/chat/completions\", \"body\": {\"model\": \"Qwen/Qwen3-0.6B\", \"messages\": [{\"role\": \"user\", \"content\": \"What is the capital of Italy?\"}], \"max_tokens\": 20}},"
+echo "      {\"custom_id\": \"task-4-small\", \"method\": \"POST\", \"url\": \"/v1/chat/completions\", \"body\": {\"model\": \"Qwen/Qwen3-0.6B\", \"messages\": [{\"role\": \"user\", \"content\": \"Write a haiku about code.\"}], \"max_tokens\": 20}},"
+echo "      {\"custom_id\": \"task-5-small\", \"method\": \"POST\", \"url\": \"/v1/chat/completions\", \"body\": {\"model\": \"Qwen/Qwen3-0.6B\", \"messages\": [{\"role\": \"user\", \"content\": \"Is Python a snake?\"}], \"max_tokens\": 20}},"
+echo "      {\"custom_id\": \"task-6-big\", \"method\": \"POST\", \"url\": \"/v1/chat/completions\", \"body\": {\"model\": \"Qwen/Qwen2.5-7B-Instruct\", \"messages\": [{\"role\": \"user\", \"content\": \"Explain quantum entanglement simply.\"}], \"max_tokens\": 50}},"
+echo "      {\"custom_id\": \"task-7-big\", \"method\": \"POST\", \"url\": \"/v1/chat/completions\", \"body\": {\"model\": \"Qwen/Qwen2.5-7B-Instruct\", \"messages\": [{\"role\": \"user\", \"content\": \"List 3 benefits of exercise.\"}], \"max_tokens\": 50}},"
+echo "      {\"custom_id\": \"task-8-big\", \"method\": \"POST\", \"url\": \"/v1/chat/completions\", \"body\": {\"model\": \"Qwen/Qwen2.5-7B-Instruct\", \"messages\": [{\"role\": \"user\", \"content\": \"Who wrote Hamlet?\"}], \"max_tokens\": 50}},"
+echo "      {\"custom_id\": \"task-9-big\", \"method\": \"POST\", \"url\": \"/v1/chat/completions\", \"body\": {\"model\": \"Qwen/Qwen2.5-7B-Instruct\", \"messages\": [{\"role\": \"user\", \"content\": \"Translate Hello to Spanish.\"}], \"max_tokens\": 50}},"
+echo "      {\"custom_id\": \"task-10-big\", \"method\": \"POST\", \"url\": \"/v1/chat/completions\", \"body\": {\"model\": \"Qwen/Qwen2.5-7B-Instruct\", \"messages\": [{\"role\": \"user\", \"content\": \"What is the speed of light?\"}], \"max_tokens\": 50}}"
+echo "    ]"
+echo "  }'"
+echo ""
+echo "=== To Check Batch Status ==="
+echo "curl http://localhost:8343/v1/batches/<BATCH_ID>"
+echo ""
+
+wait

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,16 @@ ROOT_DIR = os.path.dirname(__file__)
 
 
 def fetch_requirements(path):
+    # Keep only requirement specs: skip blanks, comments, and pip-flag lines
+    # (-r/-c/--index-url/etc.) so setuptools install_requires accepts them.
+    reqs = []
     with open(path, "r") as fd:
-        return [r.strip() for r in fd.readlines()]
+        for line in fd:
+            s = line.strip()
+            if not s or s.startswith("#") or s.startswith("-"):
+                continue
+            reqs.append(s)
+    return reqs
 
 
 def remove_prefix(text, prefix):

--- a/sllm/api_gateway.py
+++ b/sllm/api_gateway.py
@@ -54,6 +54,10 @@ origins = [origin for origin in origins_env.split(",") if origin]
 origins += ["http://localhost", "http://localhost:3000"]
 
 
+from sllm.batch_scheduler import BatchScheduler
+
+# ...
+
 def create_app(
     database: Optional[Database] = None,
     pylet_client: Optional[PyletClient] = None,
@@ -63,17 +67,16 @@ def create_app(
 ) -> FastAPI:
     """
     Create the SLLM API Gateway FastAPI application.
-
-    Args:
-        database: SQLite database instance
-        pylet_client: Pylet client instance (may be None if Pylet unavailable)
-        router: Global Router instance for request routing
-        autoscaler: AutoScaler instance (for connecting Router to it)
-        config: Head configuration
-
-    Returns:
-        FastAPI application
     """
+    
+    # Initialize Scheduler if database and router are present and enabled
+    scheduler: Optional[BatchScheduler] = None
+    if database and router:
+        if os.getenv("ENABLE_BATCH_SCHEDULER", "1").lower() in ("1", "true", "yes"):
+            scheduler = BatchScheduler(database, router)
+            logger.info("BatchScheduler enabled via config")
+        else:
+            logger.info("BatchScheduler disabled via config")
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -83,19 +86,40 @@ def create_app(
         app.state.router = router
         app.state.autoscaler = autoscaler
         app.state.config = config
+        app.state.scheduler = scheduler
 
         # Connect Router to Autoscaler for metrics push
         if router and autoscaler:
             router.set_autoscaler(autoscaler)
 
+        # Connect Scheduler to Autoscaler for proactive scaling
+        if scheduler and autoscaler:
+            scheduler.set_autoscaler(autoscaler)
+
+        # Connect Scheduler to StorageManager for checkpoint prefetch
+        storage_manager = getattr(app.state, "storage_manager", None)
+        if scheduler and storage_manager:
+            scheduler.set_storage_manager(storage_manager)
+
+        # Connect Scheduler to PyletClient for GPU-aware scaling
+        if scheduler and pylet_client:
+            scheduler.set_pylet_client(pylet_client)
+
         # Start router if provided
         if router:
             await router.start()
+
+        # Start Scheduler if initialized (default: BatchScheduler)
+        if scheduler:
+            await scheduler.start()
 
         logger.info("API Gateway started")
         yield
 
         # Cleanup
+        if scheduler and scheduler.running:
+            await scheduler.stop()
+
         if router:
             await router.drain(timeout=10.0)
             await router.stop()
@@ -283,6 +307,242 @@ def create_app(
                 status_code=500,
                 detail=f"Failed to delete deployment: {str(e)}",
             )
+
+    # -------------------------------------------------------------------------
+    # File Management Endpoints
+    # -------------------------------------------------------------------------
+
+    MAX_UPLOAD_SIZE = int(os.getenv("SLLM_MAX_UPLOAD_BYTES", str(100 * 1024 * 1024)))  # 100MB default
+    MAX_TASKS_PER_BATCH = int(os.getenv("SLLM_MAX_TASKS_PER_BATCH", "50000"))
+
+    @app.post("/v1/files")
+    async def upload_file_handler(request: Request):
+        """Upload a file that contains batch requests."""
+        # Check Content-Length header early to reject oversized uploads
+        content_length = request.headers.get("content-length")
+        if content_length and int(content_length) > MAX_UPLOAD_SIZE:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File too large. Maximum upload size is {MAX_UPLOAD_SIZE} bytes"
+            )
+
+        try:
+            form = await request.form()
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Invalid form data: {str(e)}")
+
+        file = form.get("file")
+        purpose = form.get("purpose", "batch")
+
+        if not file or not hasattr(file, "filename"):
+            raise HTTPException(status_code=400, detail="Missing file in form data")
+
+        import uuid
+        import os as _os
+        file_id = f"file_{uuid.uuid4().hex[:12]}"
+
+        # Save file to disk
+        upload_dir = "sllm_files"
+        _os.makedirs(upload_dir, exist_ok=True)
+        file_path = _os.path.join(upload_dir, f"{file_id}.jsonl")
+
+        file_content = await file.read()
+
+        if len(file_content) > MAX_UPLOAD_SIZE:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File too large. Maximum upload size is {MAX_UPLOAD_SIZE} bytes"
+            )
+
+        with open(file_path, "wb") as f:
+            f.write(file_content)
+            
+        db: Database = request.app.state.database
+        file_obj = db.create_file(
+            file_id=file_id,
+            filename=file.filename,
+            bytes_size=len(file_content),
+            purpose=purpose
+        )
+        
+        return {
+            "id": file_obj.id,
+            "object": "file",
+            "bytes": file_obj.bytes,
+            "created_at": file_obj.created_at,
+            "filename": file_obj.filename,
+            "purpose": file_obj.purpose
+        }
+
+    @app.get("/v1/files")
+    async def list_files_handler(request: Request):
+        db: Database = request.app.state.database
+        files = db.get_all_files()
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": f.id,
+                    "object": "file",
+                    "bytes": f.bytes,
+                    "created_at": f.created_at,
+                    "filename": f.filename,
+                    "purpose": f.purpose
+                } for f in files
+            ]
+        }
+
+    # -------------------------------------------------------------------------
+    # Batch Job Endpoints
+    # -------------------------------------------------------------------------
+
+    @app.post("/v1/batches")
+    async def create_batch_handler(request: Request):
+        """Create a new batch job."""
+        try:
+            body = await request.json()
+        except Exception as e:
+            raise HTTPException(
+                status_code=400, detail=f"Invalid JSON payload: {str(e)}"
+            )
+
+        input_file_id = body.get("input_file_id")
+        tasks = body.get("tasks")
+        if not input_file_id and not tasks:
+            raise HTTPException(
+                status_code=400,
+                detail="Request body must include either 'tasks' list or 'input_file_id'",
+            )
+
+        import uuid
+        import json
+        import os
+
+        db: Database = request.app.state.database
+        batch_id = f"batch_{uuid.uuid4().hex[:8]}"
+
+        # Handle file-based tasks
+        if input_file_id:
+            logger.info(f"Processing batch from file: {input_file_id}")
+            file_obj = db.get_file(input_file_id)
+            if not file_obj:
+                raise HTTPException(status_code=404, detail=f"File {input_file_id} not found")
+                
+            file_path = f"sllm_files/{input_file_id}.jsonl"
+            if not os.path.exists(file_path):
+                raise HTTPException(status_code=500, detail="File content missing on disk")
+                
+            tasks = []
+            line_idx = 0
+            try:
+                with open(file_path, "r") as f:
+                    for line_idx, line in enumerate(f):
+                        line = line.strip()
+                        if not line: continue
+                        task_data = json.loads(line)
+                        tasks.append(task_data)
+            except Exception as e:
+                raise HTTPException(status_code=400, detail=f"Failed to parse jsonl file at line {line_idx+1}: {e}")
+
+        # Validate tasks
+        if len(tasks) > MAX_TASKS_PER_BATCH:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Too many tasks ({len(tasks)}). Maximum is {MAX_TASKS_PER_BATCH} per batch."
+            )
+
+        for task in tasks:
+            if not all(
+                k in task for k in ("custom_id", "method", "url", "body")
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Each task must have custom_id, method, url, and body",
+                )
+
+        try:
+            # Create batch job
+            metadata = body.get("metadata", {})
+
+            db.create_batch_job(batch_id, metadata=metadata, input_file_id=input_file_id)
+
+            # Bulk-insert tasks in a single transaction (off event loop)
+            task_rows = [
+                {
+                    "task_id": f"task_{uuid.uuid4().hex[:16]}",
+                    "custom_id": task["custom_id"],
+                    "method": task["method"],
+                    "url": task["url"],
+                    "body": task["body"],
+                }
+                for task in tasks
+            ]
+            await asyncio.get_event_loop().run_in_executor(
+                None, db.create_batch_tasks_bulk, task_rows, batch_id
+            )
+
+            logger.info(f"Created batch job {batch_id} with {len(tasks)} tasks")
+
+            return {
+                "id": batch_id,
+                "object": "batch",
+                "status": "pending",
+                "request_counts": {
+                    "total": len(tasks),
+                    "completed": 0,
+                    "failed": 0,
+                },
+            }
+
+        except Exception as e:
+            logger.error(f"Failed to create batch job: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=500,
+                detail="Internal error creating batch job",
+            )
+
+    @app.get("/v1/batches/{batch_id}")
+    async def get_batch_handler(batch_id: str, request: Request):
+        """Get batch job status."""
+        db: Database = request.app.state.database
+        batch_job = db.get_batch_job(batch_id)
+
+        if not batch_job:
+            raise HTTPException(
+                status_code=404, detail=f"Batch job {batch_id} not found"
+            )
+
+        batch_tasks = db.get_batch_tasks(batch_id)
+
+        completed_count = sum(
+            1 for t in batch_tasks if t.status == "completed"
+        )
+        failed_count = sum(1 for t in batch_tasks if t.status == "failed")
+
+        return {
+            "id": batch_job.id,
+            "object": "batch",
+            "status": batch_job.status,
+            "metadata": batch_job.metadata,
+            "created_at": batch_job.created_at,
+            "request_counts": {
+                "total": len(batch_tasks),
+                "completed": completed_count,
+                "failed": failed_count,
+            },
+            "tasks": [
+                {
+                    "id": t.id,
+                    "custom_id": t.custom_id,
+                    "status": t.status,
+                    "body": t.body,
+                    "output": t.output,
+                    "started_at": t.started_at,
+                    "completed_at": t.completed_at,
+                }
+                for t in batch_tasks
+            ],
+        }
 
     # -------------------------------------------------------------------------
     # Inference Endpoints
@@ -533,5 +793,81 @@ def create_app(
         )
 
         return {"status": "ok"}
+
+    # ========================================================================
+    # Admin Endpoints for Experiment Control
+    # ========================================================================
+
+    @app.post("/admin/set_strategy")
+    async def set_batch_strategy(request: Request):
+        """Set batch scheduling strategy at runtime (for experiments).
+
+        Body:
+            strategy: "sync", "chunked", or "semaphore"
+            buffer_limit: Concurrency limit (default: 10)
+            enable_model_grouping: Whether to sort tasks by model (default: true)
+            enable_johnsons_rule: Whether to reorder groups via Johnson's Rule (default: true)
+            enable_prefetch: Whether to prefetch next model checkpoint (default: current)
+            prefetch_threshold: Fraction of group done before prefetch fires (default: current)
+        """
+        scheduler = request.app.state.scheduler
+        if not scheduler:
+            raise HTTPException(status_code=503, detail="Batch scheduler not available")
+
+        body = await request.json()
+        strategy = body.get("strategy", "semaphore")
+        buffer_limit = body.get("buffer_limit", 10)
+        enable_model_grouping = body.get("enable_model_grouping", True)
+        enable_johnsons_rule = body.get("enable_johnsons_rule", True)
+        enable_prefetch = body.get("enable_prefetch", scheduler.enable_prefetch)
+        prefetch_threshold = body.get("prefetch_threshold", scheduler.prefetch_threshold)
+        forced_group_order = body.get("force_group_order", [])
+
+        try:
+            scheduler.set_strategy(strategy, buffer_limit, enable_model_grouping, enable_johnsons_rule, forced_group_order)
+            scheduler.enable_prefetch = enable_prefetch
+            scheduler.prefetch_threshold = prefetch_threshold
+
+            # Tensor parallelism config: {"model_name": tp_size, ...}
+            tp_config = body.get("tp_config")
+            if tp_config and isinstance(tp_config, dict):
+                scheduler.set_tp_config(tp_config)
+
+            if not scheduler.running:
+                await scheduler.start()
+
+            logger.info(
+                f"Scheduler: prefetch={enable_prefetch}, threshold={prefetch_threshold}, johnsons_rule={enable_johnsons_rule}"
+            )
+
+            return {
+                "status": "ok",
+                "strategy": strategy,
+                "buffer_limit": buffer_limit,
+                "enable_model_grouping": enable_model_grouping,
+                "enable_johnsons_rule": enable_johnsons_rule,
+                "enable_prefetch": enable_prefetch,
+                "prefetch_threshold": prefetch_threshold,
+                "tp_config": {**scheduler._auto_tp_cache, **scheduler._tp_config},
+            }
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    @app.get("/admin/get_strategy")
+    async def get_batch_strategy(request: Request):
+        """Get current batch scheduling strategy."""
+        scheduler = request.app.state.scheduler
+        if not scheduler:
+            raise HTTPException(status_code=503, detail="Batch scheduler not available")
+
+        return {
+            "strategy": scheduler.strategy,
+            "buffer_limit": scheduler.buffer_limit,
+            "enable_model_grouping": scheduler.enable_model_grouping,
+            "enable_johnsons_rule": scheduler.enable_johnsons_rule,
+            "enable_prefetch": scheduler.enable_prefetch,
+            "prefetch_threshold": scheduler.prefetch_threshold,
+            "tp_config": {**scheduler._auto_tp_cache, **scheduler._tp_config},
+        }
 
     return app

--- a/sllm/autoscaler.py
+++ b/sllm/autoscaler.py
@@ -84,8 +84,24 @@ class AutoScaler:
         # Track idle time for keep_alive_seconds
         self._deployment_idle_times: Dict[str, int] = {}
 
+        # Batch-aware scaling: track active batch jobs per deployment
+        self._active_batches: Dict[str, set] = {}  # deployment_id -> set of batch_ids
+
         # Shutdown flag
         self._shutdown = asyncio.Event()
+
+    def register_active_batch(self, deployment_id: str, batch_id: str):
+        """Register an active batch job to prevent premature scale-down."""
+        if deployment_id not in self._active_batches:
+            self._active_batches[deployment_id] = set()
+        self._active_batches[deployment_id].add(batch_id)
+        logger.debug(f"Registered active batch {batch_id} for {deployment_id}")
+
+    def unregister_active_batch(self, deployment_id: str, batch_id: str):
+        """Unregister a completed batch job to allow scale-down."""
+        if deployment_id in self._active_batches:
+            self._active_batches[deployment_id].discard(batch_id)
+            logger.debug(f"Unregistered batch {batch_id} for {deployment_id}")
 
     def receive_metrics(
         self,
@@ -216,6 +232,15 @@ class AutoScaler:
         else:
             # Reset idle time if there's demand or we're scaling up
             self._deployment_idle_times[deployment.id] = 0
+
+        # Batch-aware scale-down: prevent scale-down if active batches exist
+        if desired < current_desired:
+            active_batches = self._active_batches.get(deployment.id, set())
+            if active_batches:
+                logger.info(
+                    f"[{deployment.id}] Preventing scale-down: {len(active_batches)} active batch jobs"
+                )
+                return  # Don't scale down while batches are running
 
         # Update if changed
         if desired != current_desired:

--- a/sllm/batch_scheduler.py
+++ b/sllm/batch_scheduler.py
@@ -1,0 +1,1566 @@
+
+import asyncio
+import math
+import os
+import subprocess
+from typing import Optional, List, Dict, Set
+from datetime import datetime, timezone
+from sllm.database import Database, BatchTask, BatchJob
+from sllm.logger import init_logger
+from sllm.router import Router
+
+logger = init_logger(__name__)
+
+
+class BatchScheduler:
+    """Offline batch scheduler for ServerlessLLM.
+
+    Designed for offline workloads where all tasks within a batch are
+    submitted before execution begins.  The scheduler processes one batch
+    at a time: it collects all pending tasks, groups them by model name
+    (and optionally by prefix hash), then executes each group sequentially
+    with aggressive checkpoint prefetching to overlap I/O with compute.
+
+    Multi-GPU utilisation is handled by the autoscaler and router — the
+    scheduler creates deployments with ``max_replicas`` equal to the
+    number of available GPUs, and the router load-balances inference
+    requests across all live endpoints.
+    """
+
+    def __init__(self, database: Database, router: Router):
+        self.database = database
+        self.router = router
+        self.running = False
+        self._loop_task: Optional[asyncio.Task] = None
+        self.autoscaler = None
+        self.pylet_client = None
+
+        # Track active batches to prevent premature scale-down
+        self._active_batch_jobs: set = set()
+
+        # Prevent concurrent processing of same batch
+        self._processing_batches: set = set()
+        self._batch_lock = asyncio.Lock()
+
+        # Runtime-configurable scheduling strategy
+        self.strategy = "semaphore"
+        self._router_buffer_size = getattr(self.router.config, 'max_buffer_size', 100)
+        self.buffer_limit = self._router_buffer_size
+        self.enable_model_grouping = True
+
+        # Checkpoint prefetch configuration
+        self.storage_manager = None
+        self.enable_prefetch = True
+        self.prefetch_threshold = 0.0  # Eager: prefetch all upcoming models immediately
+
+        # Johnson's Rule: reorder model groups to minimise I/O idle
+        self.enable_johnsons_rule = True
+
+        # Forced group ordering for experiments (overrides both alphabetical and JR)
+        self.forced_group_order: list = []
+
+        # Tensor parallelism: model_name → number of GPUs required.
+        # Auto-computed from model size vs GPU memory; manual overrides
+        # via set_tp_config() take priority.
+        self._tp_config: Dict[str, int] = {}
+        self._auto_tp_cache: Dict[str, int] = {}
+        self._gpu_mem_bytes: int = 0  # per-GPU memory, detected lazily
+
+        # Per-batch concurrency limit
+        self.max_concurrent_tasks_per_batch = max(10, self._router_buffer_size // 2)
+
+        # Global concurrency limit across ALL batches
+        self._global_semaphore = asyncio.Semaphore(self._router_buffer_size)
+
+        # Models confirmed ready in current processing cycle
+        self._models_ready: set = set()
+
+        # ----- Memory-aware prefetch -----
+        self.cpu_mem_pool_bytes: int = 0  # 0 = unknown, skip check
+        self._estimated_model_sizes: Dict[str, int] = {}
+        self._cpu_cached_models: Set[str] = set()
+
+    # ------------------------------------------------------------------ #
+    #  Setters (called by API Gateway during lifespan)                    #
+    # ------------------------------------------------------------------ #
+
+    def set_autoscaler(self, autoscaler):
+        self.autoscaler = autoscaler
+        logger.info("BatchScheduler connected to AutoScaler")
+
+    def set_pylet_client(self, pylet_client):
+        self.pylet_client = pylet_client
+        logger.info("BatchScheduler connected to PyletClient")
+
+    def set_storage_manager(self, storage_manager):
+        self.storage_manager = storage_manager
+        logger.info("BatchScheduler connected to StorageManager for prefetch")
+
+    def set_tp_config(self, tp_config: Dict[str, int]):
+        """Set manual tensor parallelism overrides per model.
+
+        Args:
+            tp_config: mapping of model_name → tensor_parallel_size.
+                       Models not listed are auto-computed from model
+                       size vs GPU memory.
+        """
+        self._tp_config = dict(tp_config)
+        logger.info(f"BatchScheduler TP manual overrides: {self._tp_config}")
+
+    def _detect_gpu_memory(self) -> int:
+        """Detect per-GPU memory in bytes (cached after first call)."""
+        if self._gpu_mem_bytes > 0:
+            return self._gpu_mem_bytes
+        try:
+            import torch
+            if torch.cuda.is_available():
+                self._gpu_mem_bytes = torch.cuda.get_device_properties(0).total_memory
+                logger.info(
+                    f"Detected GPU memory: {self._gpu_mem_bytes / 1e9:.1f} GB"
+                )
+                return self._gpu_mem_bytes
+        except Exception:
+            pass
+        # Fallback: parse nvidia-smi
+        try:
+            # Treat empty-string CUDA_VISIBLE_DEVICES like unset (startup script
+            # may export it empty when caller hasn't set it).
+            cvd = os.environ.get("CUDA_VISIBLE_DEVICES") or "0"
+            gpu_ids = cvd.split(",")[0]
+            result = subprocess.run(
+                ["nvidia-smi", f"--id={gpu_ids}",
+                 "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
+                capture_output=True, text=True, timeout=5,
+            )
+            mem_mib = int(result.stdout.strip().split("\n")[0])
+            self._gpu_mem_bytes = mem_mib * 1024 * 1024
+            logger.info(f"Detected GPU memory (nvidia-smi): {self._gpu_mem_bytes / 1e9:.1f} GB")
+            return self._gpu_mem_bytes
+        except Exception as e:
+            logger.warning(f"Cannot detect GPU memory: {e}")
+            return 0
+
+    # vLLM reserves ~10% for KV cache overhead and runtime buffers.
+    _VLLM_WEIGHT_FRACTION = 0.80
+
+    def _compute_tp(self, model_name: str) -> int:
+        """Auto-compute tensor_parallel_size from model size vs GPU memory.
+
+        Returns the smallest power-of-2 TP that fits the model weights
+        within the usable fraction of GPU memory. Falls back to 1 if
+        model size is unknown or GPU memory cannot be detected.
+        """
+        model_bytes = self._get_checkpoint_size_bytes(model_name)
+        if model_bytes <= 0:
+            return 1
+        gpu_mem = self._detect_gpu_memory()
+        if gpu_mem <= 0:
+            return 1
+        usable = gpu_mem * self._VLLM_WEIGHT_FRACTION
+        if model_bytes <= usable:
+            return 1
+        # TP must be a power of 2 for NCCL efficiency
+        raw_tp = math.ceil(model_bytes / usable)
+        tp = 1
+        while tp < raw_tp:
+            tp *= 2
+        return tp
+
+    def _get_tp(self, model_name: str) -> int:
+        """Return tensor_parallel_size for a model.
+
+        Priority: manual override > auto-cache > compute from model size.
+        """
+        if model_name in self._tp_config:
+            return self._tp_config[model_name]
+        if model_name in self._auto_tp_cache:
+            return self._auto_tp_cache[model_name]
+        tp = self._compute_tp(model_name)
+        self._auto_tp_cache[model_name] = tp
+        if tp > 1:
+            logger.info(
+                f"Auto-detected TP={tp} for {model_name} "
+                f"(weights={self._estimated_model_sizes.get(model_name, 0) / 1e9:.1f}GB, "
+                f"GPU={self._gpu_mem_bytes / 1e9:.1f}GB)"
+            )
+        return tp
+
+    # ------------------------------------------------------------------ #
+    #  Strategy                                                           #
+    # ------------------------------------------------------------------ #
+
+    def set_strategy(self, strategy: str, buffer_limit: int = 10, enable_model_grouping: bool = True, enable_johnsons_rule: bool = True, forced_group_order: list = None):
+        valid_strategies = ["sync", "chunked", "semaphore"]
+        if strategy not in valid_strategies:
+            raise ValueError(f"Invalid strategy: {strategy}. Must be one of {valid_strategies}")
+
+        self.strategy = strategy
+        effective_limit = min(buffer_limit, self._router_buffer_size)
+        if effective_limit != buffer_limit:
+            logger.info(f"buffer_limit {buffer_limit} capped to Router max_buffer_size {self._router_buffer_size}")
+        self.buffer_limit = effective_limit
+        self.enable_model_grouping = enable_model_grouping
+        self.enable_johnsons_rule = enable_johnsons_rule
+        self.forced_group_order = forced_group_order or []
+        logger.info(f"Strategy updated: {strategy}, buffer_limit={self.buffer_limit}, model_grouping={enable_model_grouping}, johnsons_rule={enable_johnsons_rule}, forced_group_order={self.forced_group_order}")
+
+    def _unregister_batch(self, batch_id: str, tasks: List[BatchTask]):
+        """Remove batch from active tracking and unregister from autoscaler."""
+        if batch_id in self._active_batch_jobs:
+            self._active_batch_jobs.remove(batch_id)
+            logger.info(f"Batch {batch_id} completed, allowing scale-down")
+            if self.autoscaler and tasks:
+                models = set(t.body.get("model") for t in tasks if t.body.get("model"))
+                for model_name in models:
+                    self.autoscaler.unregister_active_batch(f"{model_name}:vllm", batch_id)
+
+    # ------------------------------------------------------------------ #
+    #  Lifecycle                                                          #
+    # ------------------------------------------------------------------ #
+
+    async def start(self):
+        if self.running:
+            return
+        self._recover_stale_batches()
+        self.running = True
+        self._loop_task = asyncio.create_task(self._schedule_loop())
+        logger.info("BatchScheduler started")
+
+    async def stop(self):
+        logger.info("Stopping BatchScheduler...")
+        self.running = False
+        if self._loop_task:
+            self._loop_task.cancel()
+            try:
+                await self._loop_task
+            except asyncio.CancelledError:
+                pass
+        logger.info("BatchScheduler stopped")
+
+    def _recover_stale_batches(self):
+        stale_ids = [
+            bid for bid in self.database.get_pending_batch_ids()
+            if self.database.get_batch_job(bid)
+            and self.database.get_batch_job(bid).status == "in_progress"
+        ]
+        for bid in stale_ids:
+            tasks = self.database.get_batch_tasks(bid)
+            if tasks and all(t.status in ("completed", "failed") for t in tasks):
+                self.database.update_batch_job_status(bid, "completed")
+                logger.info(f"Recovered stale batch {bid} -> completed")
+            elif not tasks:
+                self.database.update_batch_job_status(bid, "completed")
+                logger.info(f"Recovered empty stale batch {bid} -> completed")
+            else:
+                self.database.update_batch_job_status(bid, "pending")
+                logger.info(f"Recovered stale batch {bid} -> pending (has unfinished tasks)")
+
+    # ------------------------------------------------------------------ #
+    #  Schedule Loop                                                      #
+    # ------------------------------------------------------------------ #
+
+    async def _schedule_loop(self):
+        background_tasks: set = set()
+
+        while self.running:
+            try:
+                pending_batch_ids = self.database.get_pending_batch_ids()
+
+                for batch_id in pending_batch_ids:
+                    async with self._batch_lock:
+                        if batch_id not in self._processing_batches:
+                            self._processing_batches.add(batch_id)
+                            task = asyncio.create_task(self._process_batch_safe(batch_id))
+                            background_tasks.add(task)
+                            task.add_done_callback(background_tasks.discard)
+
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Error in schedule loop: {e}", exc_info=True)
+                await asyncio.sleep(5)
+
+        if background_tasks:
+            logger.info(f"Waiting for {len(background_tasks)} in-flight batches to finish...")
+            await asyncio.gather(*background_tasks, return_exceptions=True)
+
+    # ------------------------------------------------------------------ #
+    #  Shared: Deployment Readiness                                       #
+    # ------------------------------------------------------------------ #
+
+    async def _get_available_gpu_count(self) -> int:
+        """Return the total number of GPUs across all online workers.
+
+        Uses *total* GPUs (not currently-free GPUs) because the batch
+        scheduler owns model lifecycle: it creates and tears down
+        deployments as needed.  If we used ``available_gpus`` instead,
+        warm replicas left over from earlier batches would make the
+        count artificially low, forcing the scheduler onto the
+        single-GPU sequential path even on a multi-GPU machine.
+        """
+        if not self.pylet_client:
+            return 1
+        try:
+            workers = await self.pylet_client.get_online_workers()
+            total = sum(w.total_gpus for w in workers)
+            return max(1, total)
+        except Exception as e:
+            logger.warning(f"Failed to query GPU count: {e}")
+            return 1
+
+    async def _ensure_deployment_ready(self, model: str, timeout: float = 300.0):
+        """Ensure a model's deployment exists and has live endpoints."""
+        if model in self._models_ready:
+            return f"{model}:vllm"
+
+        deployment_id = f"{model}:vllm"
+
+        deployment = self.database.get_deployment_by_id(deployment_id)
+        tp = self._get_tp(model)
+        # Use 0.85 to leave headroom for other processes on the same GPU.
+        gpu_mem_util = float(os.environ.get("SLLM_GPU_MEM_UTIL", "0.85"))
+        if tp > 1:
+            backend_config = {"tensor_parallel_size": tp,
+                              "gpu_memory_utilization": gpu_mem_util}
+        else:
+            backend_config = {"gpu_memory_utilization": gpu_mem_util}
+        # enforce_eager=True disables CUDA-graph capture, reducing startup time
+        # from ~50s to ~10-15s per model switch. Slightly slower per-token
+        # throughput but amortised over large batches.
+        backend_config["enforce_eager"] = True
+        if not deployment:
+            available_gpus = await self._get_available_gpu_count()
+            logger.info(f"Auto-creating deployment for {model} (max_replicas={available_gpus}, tp={tp})")
+            try:
+                self.database.create_deployment(
+                    model_name=model,
+                    backend="vllm",
+                    min_replicas=0,
+                    max_replicas=available_gpus,
+                    backend_config=backend_config,
+                )
+            except Exception as e:
+                if "already exists" in str(e):
+                    logger.info(f"Deployment {deployment_id} created by concurrent caller, continuing")
+                else:
+                    raise
+        else:
+            # Deployment exists — fix any state that would prevent scaling.
+            available_gpus = await self._get_available_gpu_count()
+            needs_update = False
+
+            # Resurrect "deleting" deployments left by previous batches.
+            if deployment.status == "deleting":
+                logger.info(f"[RESURRECT] {deployment_id}: was 'deleting', setting back to 'active'")
+                self.database.update_deployment_status(deployment_id, "active")
+                needs_update = True
+
+            # A previous batch's _prepare_gpu_allocations may have set
+            # max_replicas=0, which blocks the autoscaler.
+            if deployment.max_replicas < 1:
+                logger.info(
+                    f"[SCALE-UP] {deployment_id}: max_replicas was "
+                    f"{deployment.max_replicas}, raising to {available_gpus}"
+                )
+                needs_update = True
+
+            if needs_update:
+                self.database.update_max_replicas(deployment_id, available_gpus)
+                self.database.update_desired_replicas(deployment_id, 1)
+
+        if self.autoscaler:
+            self.autoscaler.receive_metrics(deployment_id, buffer_len=1, in_flight=0)
+
+        endpoints = self.database.get_deployment_endpoints(deployment_id)
+        if endpoints:
+            logger.info(f"[READY] {model} already has {len(endpoints)} endpoint(s)")
+            self._models_ready.add(model)
+            return deployment_id
+
+        logger.info(f"[WAIT] Waiting for {model} endpoints (timeout={timeout}s)...")
+        poll_interval = 1.0
+        elapsed = 0.0
+        while elapsed < timeout:
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+            endpoints = self.database.get_deployment_endpoints(deployment_id)
+            if endpoints:
+                logger.info(f"[READY] {model} endpoint(s) live after {elapsed:.1f}s")
+                self._models_ready.add(model)
+                return deployment_id
+            poll_interval = min(poll_interval * 1.2, 5.0)
+
+        raise TimeoutError(
+            f"Model {model} not ready after {timeout}s -- no endpoints appeared. "
+            f"Check reconciler/pylet logs."
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Memory-Aware Prefetch Guard                                        #
+    # ------------------------------------------------------------------ #
+
+    async def _can_prefetch(self, model_name: str) -> bool:
+        """Check if we have enough CPU pinned memory for prefetch."""
+        if self.cpu_mem_pool_bytes <= 0:
+            return True  # Unknown pool size, optimistically proceed
+
+        model_size = self._estimated_model_sizes.get(model_name, 0)
+        if model_size <= 0:
+            return True  # Unknown model size, optimistically proceed
+
+        used = sum(
+            self._estimated_model_sizes.get(m, 0)
+            for m in self._cpu_cached_models
+        )
+
+        if used + model_size > self.cpu_mem_pool_bytes:
+            logger.warning(
+                f"[PREFETCH] Skipping prefetch for {model_name}: "
+                f"estimated {model_size / 1e9:.1f}GB needed, "
+                f"{used / 1e9:.1f}GB/{self.cpu_mem_pool_bytes / 1e9:.1f}GB used. "
+                f"Will rely on C++ LRU eviction at load time."
+            )
+            return False
+        return True
+
+    async def _do_prefetch(self, model_name: str):
+        """Prefetch with memory guard. Updates _cpu_cached_models on success."""
+        if not await self._can_prefetch(model_name):
+            return
+        try:
+            result = await self.storage_manager.prefetch_to_cpu(model_name)
+            if result:
+                self._cpu_cached_models.add(model_name)
+        except Exception as e:
+            logger.warning(f"[PREFETCH] prefetch_to_cpu({model_name}) failed: {e}")
+
+    async def _do_unload(self, model_name: str):
+        """Proactively release GPU and CPU resources for a finished model.
+
+        Immediately cancels Pylet instances and removes DB endpoints so the
+        GPU is freed *now*, without waiting for the reconciler's 3-second
+        loop.  The reconciler will later see desired_replicas=0 and no live
+        instances, and simply skip the deployment — harmless.
+
+        Without this, the next model group is submitted to Pylet while the
+        previous instance is still alive (exclusive GPU allocation), causing
+        "0 free GPUs, waiting..." and eventual timeout.
+        """
+        deployment_id = f"{model_name}:vllm"
+
+        # 1. Signal reconciler: no replicas wanted
+        try:
+            self.database.update_desired_replicas(deployment_id, 0)
+            self.database.update_max_replicas(deployment_id, 0)
+        except Exception as e:
+            logger.warning(f"[UNLOAD] Failed to update replicas for {deployment_id}: {e}")
+
+        # 2. Immediately remove endpoints from DB so the Router stops routing
+        try:
+            self.database.remove_deployment_endpoints(deployment_id)
+        except Exception as e:
+            logger.warning(f"[UNLOAD] Failed to remove endpoints for {deployment_id}: {e}")
+
+        # 3. Invalidate ready-cache so next model group re-waits for readiness
+        self._models_ready.discard(model_name)
+
+        # 4. Directly cancel Pylet instances and wait for GPU memory to drop.
+        # pylet.cancel() marks the instance CANCELLED and releases the logical
+        # GPU slot, but the vllm EngineCore child process keeps the CUDA context
+        # alive until it fully exits.  _allocate_gpus_for_batch polls
+        # w.available_gpus (logical) which returns free immediately — but the
+        # physical GPU memory is still occupied.  The next model's vllm instance
+        # then fails with "Free memory ... less than desired utilization".
+        # Fix: after cancel, poll nvidia-smi until no process holds >1 GiB on
+        # any GPU that was used by this deployment.
+        if self.pylet_client:
+            try:
+                instances = await self.pylet_client.get_deployment_instances(deployment_id)
+                active = [
+                    inst for inst in instances
+                    if inst.status not in ("CANCELLED", "FAILED", "UNKNOWN", "COMPLETED")
+                ]
+                for inst in active:
+                    try:
+                        await self.pylet_client.cancel_instance(inst.instance_id)
+                        logger.info(
+                            f"[UNLOAD] Cancelled instance {inst.instance_id} "
+                            f"for {model_name}"
+                        )
+                    except Exception as e:
+                        logger.warning(f"[UNLOAD] cancel_instance({inst.instance_id}) failed: {e}")
+
+                if active:
+                    # Wait for all cancelled vLLM instances to fully exit.
+                    # Poll pylet instance status: once CANCELLED/COMPLETED/FAILED
+                    # the process has truly exited and GPU memory is freed.
+                    # This is more reliable than nvidia-smi (which can show
+                    # unrelated processes or CUDA-registered pinned memory).
+                    TERMINAL = {"CANCELLED", "COMPLETED", "FAILED", "UNKNOWN"}
+                    for inst in active:
+                        for _attempt in range(60):
+                            await asyncio.sleep(1)
+                            try:
+                                info = await self.pylet_client.get_instance(inst.instance_id)
+                                if info is None or info.status in TERMINAL:
+                                    logger.info(
+                                        f"[UNLOAD] GPU memory released after "
+                                        f"{_attempt + 1}s for {model_name} "
+                                        f"(instance {inst.instance_id} → {info.status if info else 'gone'})"
+                                    )
+                                    break
+                            except Exception as _e:
+                                logger.debug(f"[UNLOAD] instance status poll failed: {_e}")
+                                break  # can't poll → assume done
+                        else:
+                            logger.warning(
+                                f"[UNLOAD] GPU memory still held after 60s for "
+                                f"{model_name} — proceeding anyway"
+                            )
+            except Exception as e:
+                logger.warning(f"[UNLOAD] Failed to query/cancel instances for {deployment_id}: {e}")
+
+        # 5. Evict from pinned CPU memory
+        if self.storage_manager:
+            try:
+                result = await self.storage_manager.unload_from_cpu(model_name)
+                if result:
+                    self._cpu_cached_models.discard(model_name)
+                    logger.info(f"[UNLOAD] {model_name} evicted from pinned memory")
+            except Exception as e:
+                logger.warning(f"[UNLOAD] unload_from_cpu({model_name}) failed: {e}")
+
+        logger.info(f"[UNLOAD] {model_name} resources released (GPU + CPU)")
+
+    # ------------------------------------------------------------------ #
+    #  GPU Allocation for Multi-GPU Batches                                #
+    # ------------------------------------------------------------------ #
+
+    async def _prepare_gpu_allocations(
+        self,
+        batch_id: str,
+        num_replicas_per_model: Dict[str, int],
+        num_gpus: int,
+        peak_gpus: int = None,
+    ):
+        """Ensure GPU allocations match batch requirements before launching.
+
+        Without this step, leftover replicas from previous batches or
+        baselines can hog all GPUs, deadlocking new model deployments.
+
+        Steps:
+        1. For models NOT in this batch: scale to 0 and unregister from
+           autoscaler so the batch-aware scale-down guard lets them go.
+        2. For models IN this batch but over-provisioned: cap max_replicas
+           and desired_replicas to the assigned count.
+        3. Wait for the reconciler to tear down excess instances so GPUs
+           are actually freed.
+        """
+        batch_models = set(num_replicas_per_model.keys())
+        all_deployments = self.database.get_all_deployments()
+        need_to_wait = False
+
+        for deployment in all_deployments:
+            if deployment.status == "deleting":
+                continue
+
+            deployment_id = deployment.id
+            model_name = deployment.model_name
+            current_endpoints = self.database.get_deployment_endpoints(deployment_id)
+            current_count = len(current_endpoints)
+
+            if model_name not in batch_models:
+                # Not needed for this batch — scale to 0
+                if current_count > 0:
+                    logger.info(
+                        f"[GPU-ALLOC] {deployment_id}: not needed for batch, "
+                        f"scaling {current_count} → 0"
+                    )
+                    # Unregister from autoscaler so batch-aware guard allows scale-down
+                    if self.autoscaler:
+                        for bid in list(self.autoscaler._active_batches.get(deployment_id, set())):
+                            self.autoscaler.unregister_active_batch(deployment_id, bid)
+                    self.database.update_max_replicas(deployment_id, 0)
+                    self.database.update_desired_replicas(deployment_id, 0)
+                    need_to_wait = True
+            else:
+                # Needed, but may be over-provisioned
+                needed = num_replicas_per_model[model_name]
+                if current_count > needed:
+                    logger.info(
+                        f"[GPU-ALLOC] {deployment_id}: has {current_count} replicas, "
+                        f"batch needs {needed} — scaling down"
+                    )
+                    # Unregister stale batch refs so autoscaler permits scale-down
+                    if self.autoscaler:
+                        for bid in list(self.autoscaler._active_batches.get(deployment_id, set())):
+                            if bid != batch_id:
+                                self.autoscaler.unregister_active_batch(deployment_id, bid)
+                    self.database.update_max_replicas(deployment_id, needed)
+                    self.database.update_desired_replicas(deployment_id, needed)
+                    need_to_wait = True
+
+        if not need_to_wait:
+            return
+
+        # Clear models_ready cache — replica counts changed
+        self._models_ready.clear()
+
+        # Wait for reconciler to actually free the GPUs
+        if self.pylet_client:
+            # peak_gpus reflects the maximum SIMULTANEOUS GPU usage (models on the
+            # same sequential lane don't stack).  Fall back to the naive sum if not
+            # provided (e.g. called from outside _process_with_prefetch).
+            total_needed = peak_gpus if peak_gpus is not None else sum(
+                reps * self._get_tp(model)
+                for model, reps in num_replicas_per_model.items()
+            )
+            logger.info(
+                f"[GPU-ALLOC] Waiting for GPUs (need {total_needed} free "
+                f"out of {num_gpus} total)..."
+            )
+            for attempt in range(180):  # Up to 3 minutes
+                try:
+                    workers = await self.pylet_client.get_online_workers()
+                    free = sum(w.available_gpus for w in workers)
+                    if free >= total_needed:
+                        logger.info(
+                            f"[GPU-ALLOC] {free}/{num_gpus} GPUs available "
+                            f"after {attempt}s"
+                        )
+                        return
+                except Exception as e:
+                    logger.debug(f"[GPU-ALLOC] Poll failed: {e}")
+                await asyncio.sleep(1)
+
+            logger.warning(
+                "[GPU-ALLOC] Timed out waiting for GPU reclamation, "
+                "proceeding anyway (may deadlock)"
+            )
+
+    # ------------------------------------------------------------------ #
+    #  Batch Processing                                                    #
+    # ------------------------------------------------------------------ #
+
+    async def _process_batch_safe(self, batch_id: str):
+        try:
+            await self._process_batch(batch_id)
+        except Exception as e:
+            logger.error(f"Batch {batch_id} failed with: {e}")
+            # Mark remaining pending tasks as failed so the batch
+            # can be finalised instead of stuck at in_progress forever.
+            try:
+                tasks = self.database.get_batch_tasks(batch_id)
+                pending = [t for t in tasks if t.status == "pending"]
+                for t in pending:
+                    self.database.update_batch_task_result(
+                        task_id=t.id,
+                        status="failed",
+                        output={"error": str(e)},
+                    )
+                self.database.update_batch_job_status(batch_id, "failed")
+                self._unregister_batch(batch_id, tasks)
+                logger.info(
+                    f"Batch {batch_id} marked as failed "
+                    f"({len(pending)} pending tasks marked failed)"
+                )
+            except Exception as cleanup_err:
+                logger.error(f"Failed to clean up batch {batch_id}: {cleanup_err}")
+        finally:
+            async with self._batch_lock:
+                self._processing_batches.discard(batch_id)
+
+    async def _process_batch(self, batch_id: str):
+        tasks = self.database.get_batch_tasks(batch_id)
+        retries = 0
+        while not tasks and retries < 10:
+            await asyncio.sleep(0.5)
+            tasks = self.database.get_batch_tasks(batch_id)
+            retries += 1
+        if not tasks:
+            logger.warning(f"Batch {batch_id} has no tasks after waiting, skipping")
+            return
+
+        self._models_ready.clear()
+
+        pending_tasks = [t for t in tasks if t.status == 'pending']
+
+        if not pending_tasks:
+            if tasks and all(t.status in ('completed', 'failed') for t in tasks):
+                self.database.update_batch_job_status(batch_id, 'completed')
+                self._unregister_batch(batch_id, tasks)
+            return
+
+        self.database.update_batch_job_status(batch_id, 'in_progress')
+        self._active_batch_jobs.add(batch_id)
+
+        # Register batch with autoscaler to prevent premature scale-down
+        if self.autoscaler:
+            models_in_batch = set(t.body.get("model") for t in pending_tasks if t.body.get("model"))
+            for model_name in models_in_batch:
+                self.autoscaler.register_active_batch(f"{model_name}:vllm", batch_id)
+
+        if self.enable_model_grouping:
+            if self.forced_group_order:
+                order_map = {m: i for i, m in enumerate(self.forced_group_order)}
+                pending_tasks.sort(key=lambda t: order_map.get(t.body.get("model", ""), 999))
+                logger.info(f"Model grouping enabled: tasks sorted by forced order {self.forced_group_order}")
+            else:
+                pending_tasks.sort(key=lambda t: t.body.get("model", ""))
+                logger.info(f"Model grouping enabled: tasks sorted by model name (alphabetical)")
+        else:
+            logger.info(f"Model grouping disabled: preserving original task order")
+
+        use_prefetch = (
+            self.enable_prefetch
+            and self.enable_model_grouping
+            and self.storage_manager is not None
+        )
+
+        if self.enable_model_grouping:
+            await self._process_with_prefetch(pending_tasks, do_prefetch=use_prefetch)
+        else:
+            await self._process_without_prefetch(pending_tasks)
+
+        all_tasks = self.database.get_batch_tasks(batch_id)
+        if all_tasks and all(t.status in ('completed', 'failed') for t in all_tasks):
+            self.database.update_batch_job_status(batch_id, 'completed')
+            self._unregister_batch(batch_id, all_tasks)
+
+    # ------------------------------------------------------------------ #
+    #  Shared: Non-prefetch execution                                     #
+    # ------------------------------------------------------------------ #
+
+    async def _process_without_prefetch(self, pending_tasks: List[BatchTask]):
+        if self.strategy == "sync":
+            logger.info(f"Processing {len(pending_tasks)} tasks with SYNC strategy")
+            current_model = None
+            for task in pending_tasks:
+                task_model = task.body.get("model")
+                if task_model and current_model and task_model != current_model:
+                    logger.info(f"Model switch: {current_model} -> {task_model}, unloading current")
+                    await self._do_unload(current_model)
+                current_model = task_model
+                await self._execute_task(task)
+
+        elif self.strategy == "chunked":
+            chunk_size = max(1, self.max_concurrent_tasks_per_batch)
+            logger.info(f"Processing {len(pending_tasks)} tasks with CHUNKED strategy (chunk_size: {chunk_size})")
+            for i in range(0, len(pending_tasks), chunk_size):
+                chunk = pending_tasks[i : i + chunk_size]
+                await asyncio.gather(*[self._execute_task(task) for task in chunk])
+
+        else:  # semaphore
+            semaphore = asyncio.Semaphore(self.max_concurrent_tasks_per_batch)
+
+            async def _sem_execute(task):
+                async with semaphore:
+                    await self._execute_task(task)
+
+            logger.info(f"Processing {len(pending_tasks)} tasks with SEMAPHORE strategy (limit: {self.max_concurrent_tasks_per_batch})")
+            await asyncio.gather(*(_sem_execute(task) for task in pending_tasks))
+
+    # ------------------------------------------------------------------ #
+    #  Shared: Prefetch path                                              #
+    # ------------------------------------------------------------------ #
+
+    def _estimate_group_time(self, model_name: str, num_tasks: int, model_load_time_s: float = 90.0) -> tuple:
+        """Return (i_time, p_time) for a model group."""
+        size_bytes = self._get_checkpoint_size_bytes(model_name)
+        if size_bytes > 0:
+            i_time = size_bytes / self._NVME_READ_BPS
+            per_task = self._BASE_TASK_TIME_S * (size_bytes / self._BASE_MODEL_BYTES)
+        else:
+            i_time = model_load_time_s
+            per_task = self._BASE_TASK_TIME_S
+        p_time = num_tasks * per_task
+        return i_time, p_time
+
+    def _assign_groups_to_gpus(
+        self,
+        groups: List[tuple],
+        num_gpus: int,
+    ) -> List[List[tuple]]:
+        """Assign model groups to execution lanes using capacity-aware packing.
+
+        Each lane is a logical execution slot that processes its groups
+        sequentially.  All lanes run in parallel.  A lane's *budget* is
+        the number of physical GPUs it occupies while running.
+
+        **TP lane packing** (first-fit decreasing):
+          - Each TP>1 group gets its own lane (budget = tp) when GPU
+            budget allows, enabling parallel execution of TP models.
+          - When budget is insufficient, groups with the same TP size
+            share a lane (sequential within lane).
+          - At least 1 GPU is reserved for TP=1 groups when they exist.
+
+        **TP=1 lanes:** remaining GPU slots are filled with single-GPU
+        lanes.  Groups are assigned via greedy LPT, then rebalanced.
+
+        Returns a list of per-lane queues (variable length, not
+        necessarily equal to ``num_gpus``).
+        """
+        if num_gpus <= 1:
+            return [groups]
+
+        # ----- Separate TP>1 and TP=1 groups -----
+        tp_groups = []
+        single_groups = []
+        for model_name, tasks in groups:
+            tp = self._get_tp(model_name)
+            if tp > 1:
+                i_time, p_time = self._estimate_group_time(model_name, len(tasks))
+                tp_groups.append((model_name, tasks, tp, i_time + self._MODEL_SWITCH_OVERHEAD_S + p_time))
+            else:
+                single_groups.append((model_name, tasks))
+
+        # Sort TP groups: largest TP first, then longest first (FFD)
+        tp_groups.sort(key=lambda x: (-x[2], -x[3]))
+
+        # ----- Pack TP groups into lanes -----
+        # Each lane: [budget, [(model, tasks), ...], load]
+        tp_lanes: List[List] = []       # [[budget, groups_list, load], ...]
+        used_budget = 0
+        reserve = 1 if single_groups else 0  # keep ≥1 GPU for TP=1
+
+        for model_name, tasks, tp, total_time in tp_groups:
+            if tp > num_gpus:
+                logger.warning(
+                    f"[MULTI-GPU] TP={tp} for {model_name} exceeds available "
+                    f"GPUs ({num_gpus}) — creating lane anyway"
+                )
+                tp_lanes.append([tp, [(model_name, tasks)], total_time])
+                used_budget += tp
+                continue
+
+            # Try to create a new parallel lane if budget allows
+            if used_budget + tp <= num_gpus - reserve:
+                tp_lanes.append([tp, [(model_name, tasks)], total_time])
+                used_budget += tp
+                logger.info(
+                    f"[MULTI-GPU] TP={tp} model {model_name} → lane {len(tp_lanes)-1} "
+                    f"(budget={tp}, parallel)"
+                )
+            else:
+                # Not enough GPUs — add to existing lane with same TP size
+                candidates = [l for l in tp_lanes if l[0] == tp]
+                if candidates:
+                    target = min(candidates, key=lambda l: l[2])
+                    target[1].append((model_name, tasks))
+                    target[2] += total_time
+                    lane_idx = tp_lanes.index(target)
+                    logger.info(
+                        f"[MULTI-GPU] TP={tp} model {model_name} → lane {lane_idx} "
+                        f"(budget={tp}, sequential, shared)"
+                    )
+                else:
+                    # No matching lane — create one anyway (over-subscription)
+                    tp_lanes.append([tp, [(model_name, tasks)], total_time])
+                    used_budget += tp
+                    logger.warning(
+                        f"[MULTI-GPU] TP={tp} model {model_name} → lane {len(tp_lanes)-1} "
+                        f"(budget={tp}, over-subscribed)"
+                    )
+
+        # ----- TP=1 lanes -----
+        remaining_gpus = num_gpus - used_budget
+
+        # Annotate and sort single groups by LPT
+        annotated = []
+        for model_name, tasks in single_groups:
+            i_time, p_time = self._estimate_group_time(model_name, len(tasks))
+            annotated.append((model_name, tasks, i_time + self._MODEL_SWITCH_OVERHEAD_S + p_time))
+        annotated.sort(key=lambda x: x[2], reverse=True)
+
+        if remaining_gpus <= 0 and single_groups:
+            # All GPUs consumed by TP lanes — no room for parallel TP=1 lanes.
+            # Append TP=1 groups sequentially into the least-loaded TP lane so
+            # they run after the TP model finishes (once GPUs are freed).
+            logger.info(
+                f"[MULTI-GPU] No free GPUs for TP=1 models "
+                f"(used_budget={used_budget}/{num_gpus}); "
+                f"scheduling TP=1 groups sequentially in TP lane(s)"
+            )
+            for model_name, tasks, total_time in annotated:
+                if tp_lanes:
+                    target = min(tp_lanes, key=lambda l: l[2])
+                    target[1].append((model_name, tasks))
+                    target[2] += total_time
+                    lane_idx = tp_lanes.index(target)
+                    logger.info(
+                        f"[MULTI-GPU] TP=1 model {model_name} → lane {lane_idx} "
+                        f"(sequential after TP={target[0]}, no free GPUs)"
+                    )
+                else:
+                    tp_lanes.append([1, [(model_name, tasks)], total_time])
+                    used_budget += 1
+            single_groups = []
+            annotated = []
+
+        remaining_gpus = max(0, remaining_gpus)
+        single_queues: List[List[tuple]] = [[] for _ in range(remaining_gpus)]
+        single_loads = [0.0] * remaining_gpus
+
+        for model_name, tasks, total_time in annotated:
+            target = single_loads.index(min(single_loads))
+            single_queues[target].append((model_name, tasks))
+            single_loads[target] += total_time
+
+        # ----- Rebalance TP=1 lanes only -----
+        IMBALANCE_THRESHOLD = 0.15
+        MAX_REBALANCE_ITERS = remaining_gpus * max(len(single_groups), 1)
+
+        for _ in range(MAX_REBALANCE_ITERS):
+            if remaining_gpus < 2:
+                break
+            slowest = max(range(remaining_gpus), key=lambda i: single_loads[i])
+            fastest = min(range(remaining_gpus), key=lambda i: single_loads[i])
+
+            if slowest == fastest:
+                break
+
+            imbalance = (
+                (single_loads[slowest] - single_loads[fastest])
+                / max(single_loads[slowest], 1e-9)
+            )
+            if imbalance <= IMBALANCE_THRESHOLD:
+                break
+
+            if not single_queues[slowest]:
+                break
+            heaviest_idx = max(
+                range(len(single_queues[slowest])),
+                key=lambda j: len(single_queues[slowest][j][1]),
+            )
+            h_model, h_tasks = single_queues[slowest][heaviest_idx]
+
+            if len(h_tasks) < 2:
+                break
+
+            i_time, _ = self._estimate_group_time(h_model, 1)
+            # Add irreducible GPU init cost: creating a new replica on a GPU requires
+            # vLLM CUDA init + warmup even when weights are pre-loaded into CPU memory.
+            i_time += self._MODEL_SWITCH_OVERHEAD_S
+            _, p_all = self._estimate_group_time(h_model, len(h_tasks))
+            per_task_time = p_all / len(h_tasks)
+
+            gap = single_loads[slowest] - single_loads[fastest] - i_time
+            if gap <= 0:
+                break
+
+            n_move = int(gap / (2 * per_task_time))
+            n_move = max(1, min(n_move, len(h_tasks) - 1))
+
+            keep_tasks = h_tasks[:-n_move]
+            move_tasks = h_tasks[-n_move:]
+            single_queues[slowest][heaviest_idx] = (h_model, keep_tasks)
+
+            existing_idx = None
+            for j, (m, _) in enumerate(single_queues[fastest]):
+                if m == h_model:
+                    existing_idx = j
+                    break
+
+            if existing_idx is not None:
+                _, existing_tasks = single_queues[fastest][existing_idx]
+                single_queues[fastest][existing_idx] = (h_model, existing_tasks + move_tasks)
+            else:
+                single_queues[fastest].append((h_model, move_tasks))
+
+            for i in [slowest, fastest]:
+                single_loads[i] = sum(
+                    self._estimate_group_time(m, len(t))[0]
+                    + self._MODEL_SWITCH_OVERHEAD_S
+                    + self._estimate_group_time(m, len(t))[1]
+                    for m, t in single_queues[i]
+                )
+
+            logger.info(
+                f"[REBALANCE] Moved {n_move} {h_model} tasks "
+                f"(loads: {', '.join(f'Lane {i}={single_loads[i]:.1f}s' for i in range(remaining_gpus))})"
+            )
+
+        # ----- Combine: TP lanes first, then non-empty TP=1 lanes -----
+        all_queues: List[List[tuple]] = [lane[1] for lane in tp_lanes]
+        all_loads = [lane[2] for lane in tp_lanes]
+        tp_lane_count = len(tp_lanes)
+
+        for i, q in enumerate(single_queues):
+            if q:
+                all_queues.append(q)
+                all_loads.append(single_loads[i])
+
+        # Summary logging
+        parts = []
+        for i, q in enumerate(all_queues):
+            if i < tp_lane_count:
+                budget = tp_lanes[i][0]
+                parts.append(
+                    f"Lane {i} [TP={budget}]: "
+                    f"[{', '.join(f'{m}({len(t)})' for m, t in q)}] "
+                    f"load={all_loads[i]:.1f}s"
+                )
+            else:
+                parts.append(
+                    f"Lane {i}: "
+                    f"[{', '.join(f'{m}({len(t)})' for m, t in q)}] "
+                    f"load={all_loads[i]:.1f}s"
+                )
+        total_budget = used_budget + sum(1 for q in single_queues if q)
+        logger.info(
+            f"[MULTI-GPU] Assigned {len(groups)} groups to {len(all_queues)} lanes "
+            f"({total_budget} GPU slots): " + ", ".join(parts)
+        )
+        return all_queues
+
+    async def _process_gpu_queue(
+        self,
+        gpu_id: int,
+        queue: List[tuple],
+        do_prefetch: bool,
+        num_replicas_per_model: Dict[str, int],
+        model_lane_refs: Dict[str, int] = None,
+        model_ref_lock: asyncio.Lock = None,
+    ):
+        """Process a single GPU's queue of model groups sequentially."""
+        # Track which models still have future groups in THIS queue
+        remaining_in_queue = {}
+        for idx, (m, _) in enumerate(queue):
+            remaining_in_queue.setdefault(m, []).append(idx)
+
+        # Eager prefetch: kick off all subsequent models at the start
+        if do_prefetch and self.storage_manager and len(queue) > 1:
+            subsequent_models = list(dict.fromkeys(m for m, _ in queue[1:]))
+            for m in subsequent_models:
+                if m != queue[0][0] and await self._can_prefetch(m):
+                    logger.info(f"[GPU {gpu_id}] Eagerly prefetching {m} to CPU")
+                    asyncio.create_task(self._do_prefetch(m))
+
+        for group_idx, (model_name, group_tasks) in enumerate(queue):
+            replicas = num_replicas_per_model.get(model_name, 1)
+            await self._ensure_deployment_ready_with_replicas(model_name, replicas)
+
+            logger.info(
+                f"[GPU {gpu_id}] Starting group {group_idx+1}/{len(queue)}: "
+                f"{model_name} ({len(group_tasks)} tasks, {replicas} replica(s))"
+            )
+
+            await self._execute_group(group_tasks)
+
+            # Proactive eviction: unload model if no future groups need it
+            # in THIS queue AND no other lanes still need it.
+            remaining_in_queue[model_name].pop(0)
+            if not remaining_in_queue[model_name]:
+                if model_lane_refs is not None and model_ref_lock is not None:
+                    async with model_ref_lock:
+                        model_lane_refs[model_name] -= 1
+                        should_unload = model_lane_refs[model_name] <= 0
+                    if should_unload:
+                        await self._do_unload(model_name)
+                    else:
+                        logger.info(
+                            f"[GPU {gpu_id}] {model_name} done on this lane, "
+                            f"{model_lane_refs[model_name]} lane(s) still active"
+                        )
+                else:
+                    # Single-lane or legacy path — safe to unload
+                    await self._do_unload(model_name)
+
+    async def _ensure_deployment_ready_with_replicas(self, model: str, max_replicas: int, timeout: float = 300.0):
+        """Like _ensure_deployment_ready but with a specific replica count."""
+        if model in self._models_ready:
+            return f"{model}:vllm"
+
+        deployment_id = f"{model}:vllm"
+        tp = self._get_tp(model)
+        gpu_mem_util = float(os.environ.get("SLLM_GPU_MEM_UTIL", "0.85"))
+        if tp > 1:
+            backend_config = {"tensor_parallel_size": tp,
+                              "gpu_memory_utilization": gpu_mem_util}
+        else:
+            backend_config = {"gpu_memory_utilization": gpu_mem_util}
+        backend_config["enforce_eager"] = True
+        deployment = self.database.get_deployment_by_id(deployment_id)
+        if not deployment:
+            logger.info(f"Auto-creating deployment for {model} (max_replicas={max_replicas}, tp={tp})")
+            try:
+                self.database.create_deployment(
+                    model_name=model,
+                    backend="vllm",
+                    min_replicas=0,
+                    max_replicas=max_replicas,
+                    backend_config=backend_config,
+                )
+            except Exception as e:
+                if "already exists" in str(e):
+                    logger.info(f"Deployment {deployment_id} created by concurrent caller, continuing")
+                else:
+                    raise
+        else:
+            # Deployment exists — fix any state that would prevent scaling.
+            needs_update = False
+
+            # Resurrect "deleting" deployments left by previous batches.
+            if deployment.status == "deleting":
+                logger.info(f"[RESURRECT] {deployment_id}: was 'deleting', setting back to 'active'")
+                self.database.update_deployment_status(deployment_id, "active")
+                needs_update = True
+
+            # A previous batch's _prepare_gpu_allocations may have set
+            # max_replicas=0, which blocks the autoscaler.
+            if deployment.max_replicas < max_replicas:
+                logger.info(
+                    f"[SCALE-UP] {deployment_id}: max_replicas was "
+                    f"{deployment.max_replicas}, raising to {max_replicas}"
+                )
+                needs_update = True
+
+            if needs_update:
+                self.database.update_max_replicas(deployment_id, max_replicas)
+                self.database.update_desired_replicas(deployment_id, max_replicas)
+
+        if self.autoscaler:
+            self.autoscaler.receive_metrics(deployment_id, buffer_len=1, in_flight=0)
+
+        endpoints = self.database.get_deployment_endpoints(deployment_id)
+        if endpoints:
+            logger.info(f"[READY] {model} already has {len(endpoints)} endpoint(s)")
+            self._models_ready.add(model)
+            return deployment_id
+
+        logger.info(f"[WAIT] Waiting for {model} endpoints (timeout={timeout}s)...")
+        poll_interval = 1.0
+        elapsed = 0.0
+        while elapsed < timeout:
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+            endpoints = self.database.get_deployment_endpoints(deployment_id)
+            if endpoints:
+                logger.info(f"[READY] {model} endpoint(s) live after {elapsed:.1f}s")
+                self._models_ready.add(model)
+                return deployment_id
+            poll_interval = min(poll_interval * 1.2, 5.0)
+
+        raise TimeoutError(
+            f"Model {model} not ready after {timeout}s -- no endpoints appeared. "
+            f"Check reconciler/pylet logs."
+        )
+
+    async def _process_with_prefetch(self, pending_tasks: List[BatchTask], do_prefetch: bool = True):
+        groups = self._extract_model_groups(pending_tasks)
+        num_gpus = await self._get_available_gpu_count()
+
+        if num_gpus <= 1:
+            # Single GPU: original path — Johnson's Rule on the global queue
+            if self.enable_johnsons_rule and not self.forced_group_order and len(groups) > 1:
+                groups = self._apply_johnsons_rule(groups)
+            logger.info(
+                f"[PREFETCH] Processing {len(pending_tasks)} tasks "
+                f"(prefetch={'ON' if do_prefetch else 'OFF'}, threshold={self.prefetch_threshold}) in {len(groups)} "
+                f"model groups (1 GPU): {[g[0] for g in groups]}"
+            )
+            await self._run_single_gpu_queue(groups, do_prefetch)
+            return
+
+        # --- Multi-GPU path ---
+        # 1. Assign groups to GPUs (greedy least-load).
+        #    Exception: when a forced group order is set, honour it exactly by
+        #    placing all groups in a single sequential lane in that order.
+        #    _assign_groups_to_gpus would otherwise reorder by TP and LPT,
+        #    ignoring the forced sequence (breaks JR ordering experiments).
+        if self.forced_group_order:
+            gpu_queues = [groups]
+            logger.info(
+                f"[FORCED-ORDER] Using single lane for forced group order "
+                f"{[g[0] for g in groups]}"
+            )
+        else:
+            gpu_queues = self._assign_groups_to_gpus(groups, num_gpus)
+
+        # 2. Per-GPU: apply Johnson's Rule to each queue independently
+        if self.enable_johnsons_rule and not self.forced_group_order:
+            for i, queue in enumerate(gpu_queues):
+                if len(queue) > 1:
+                    gpu_queues[i] = self._apply_johnsons_rule(queue)
+                    logger.info(f"[GPU {i}] Johnson's order: {[g[0] for g in gpu_queues[i]]}")
+
+        # 3. Count how many GPUs each model is assigned to (for replica count)
+        num_replicas_per_model: Dict[str, int] = {}
+        for queue in gpu_queues:
+            for model_name, _tasks in queue:
+                num_replicas_per_model[model_name] = num_replicas_per_model.get(model_name, 0) + 1
+
+        logger.info(
+            f"[MULTI-GPU] Processing {len(pending_tasks)} tasks across {num_gpus} GPUs, "
+            f"replicas: {num_replicas_per_model}"
+        )
+
+        # 4. Reclaim GPUs from over-provisioned / unneeded deployments
+        #    Must happen BEFORE launching GPU queues to avoid deadlock
+        #    where leftover replicas block new model deployments.
+        batch_id = pending_tasks[0].batch_id if pending_tasks else ""
+        # Peak simultaneous GPU demand: models in the SAME lane run sequentially,
+        # so only count the heaviest model per lane (not the sum of all models).
+        peak_gpus_needed = sum(
+            max(self._get_tp(m) for m, _ in queue)
+            for queue in gpu_queues
+            if queue
+        )
+        await self._prepare_gpu_allocations(batch_id, num_replicas_per_model, num_gpus, peak_gpus=peak_gpus_needed)
+
+        # 5. Build shared reference counter for cross-lane eviction safety.
+        #    Each lane that has a model increments the counter.  Only the
+        #    last lane to finish with a model calls _do_unload.
+        model_lane_refs: Dict[str, int] = {}
+        for queue in gpu_queues:
+            seen = set()
+            for model_name, _ in queue:
+                if model_name not in seen:
+                    model_lane_refs[model_name] = model_lane_refs.get(model_name, 0) + 1
+                    seen.add(model_name)
+        model_ref_lock = asyncio.Lock()
+
+        # 6. Execute all GPU queues in parallel
+        gpu_coroutines = []
+        for gpu_id, queue in enumerate(gpu_queues):
+            if queue:
+                gpu_coroutines.append(
+                    self._process_gpu_queue(
+                        gpu_id, queue, do_prefetch, num_replicas_per_model,
+                        model_lane_refs=model_lane_refs,
+                        model_ref_lock=model_ref_lock,
+                    )
+                )
+        await asyncio.gather(*gpu_coroutines)
+
+    async def _run_single_gpu_queue(self, groups: List[tuple], do_prefetch: bool):
+        """Original single-GPU execution path."""
+        # Build remaining-group tracker for proactive eviction
+        remaining = {}
+        for idx, (m, _) in enumerate(groups):
+            remaining.setdefault(m, []).append(idx)
+
+        if do_prefetch and self.prefetch_threshold == 0.0:
+            # === EAGER PREFETCH MODE ===
+            if self.storage_manager and len(groups) > 1:
+                subsequent_models = list(dict.fromkeys(g[0] for g in groups[1:]))
+                for m in subsequent_models:
+                    if m != groups[0][0]:
+                        if await self._can_prefetch(m):
+                            logger.info(f"[PREFETCH_ALL] Eagerly prefetching {m} to CPU right now")
+                            asyncio.create_task(self._do_prefetch(m))
+
+            for group_idx, (model_name, group_tasks) in enumerate(groups):
+                await self._ensure_deployment_ready(model_name)
+                logger.info(
+                    f"Starting group {group_idx+1}/{len(groups)}: "
+                    f"{model_name} ({len(group_tasks)} tasks) (Eager Mode)"
+                )
+                await self._execute_group(group_tasks)
+
+                # Proactive eviction
+                remaining[model_name].pop(0)
+                if not remaining[model_name]:
+                    await self._do_unload(model_name)
+
+        else:
+            # === OVERLAPPING PREFETCH MODE or NO-PREFETCH GROUP MODE ===
+            for group_idx, (model_name, group_tasks) in enumerate(groups):
+                await self._ensure_deployment_ready(model_name)
+                next_model = (
+                    groups[group_idx + 1][0]
+                    if group_idx + 1 < len(groups)
+                    else None
+                )
+
+                logger.info(
+                    f"[PREFETCH] Starting group {group_idx+1}/{len(groups)}: "
+                    f"{model_name} ({len(group_tasks)} tasks)"
+                )
+
+                if do_prefetch and next_model and next_model != model_name:
+                    await self._execute_group_with_prefetch(
+                        group_tasks, next_model, self.prefetch_threshold
+                    )
+                else:
+                    await self._execute_group(group_tasks)
+
+                # Proactive eviction
+                remaining[model_name].pop(0)
+                if not remaining[model_name]:
+                    await self._do_unload(model_name)
+
+    async def _execute_group_with_prefetch(
+        self,
+        tasks: List[BatchTask],
+        next_model: str,
+        threshold: float,
+    ):
+        prefetch_at = max(1, int(len(tasks) * threshold))
+        prefetch_triggered = False
+        completed_count = 0
+        lock = asyncio.Lock()
+
+        semaphore = asyncio.Semaphore(self.max_concurrent_tasks_per_batch)
+
+        async def _execute_and_track(task):
+            nonlocal completed_count, prefetch_triggered
+
+            async with semaphore:
+                await self._execute_task(task)
+
+            async with lock:
+                completed_count += 1
+
+                if (
+                    not prefetch_triggered
+                    and completed_count >= prefetch_at
+                    and self.storage_manager
+                ):
+                    prefetch_triggered = True
+                    if await self._can_prefetch(next_model):
+                        logger.info(
+                            f"[PREFETCH] {completed_count}/{len(tasks)} done "
+                            f"(threshold {threshold:.0%}), prefetching {next_model}"
+                        )
+                        asyncio.create_task(self._do_prefetch(next_model))
+                    else:
+                        logger.info(
+                            f"[PREFETCH] {completed_count}/{len(tasks)} done "
+                            f"but skipping prefetch for {next_model} (memory)"
+                        )
+
+        await asyncio.gather(*[_execute_and_track(t) for t in tasks])
+
+    async def _execute_group(self, tasks: List[BatchTask]):
+        if self.strategy == "sync":
+            for task in tasks:
+                await self._execute_task(task)
+        elif self.strategy == "chunked":
+            chunk_size = max(1, self.max_concurrent_tasks_per_batch)
+            for i in range(0, len(tasks), chunk_size):
+                chunk = tasks[i : i + chunk_size]
+                await asyncio.gather(*[self._execute_task(t) for t in chunk])
+        else:
+            semaphore = asyncio.Semaphore(self.max_concurrent_tasks_per_batch)
+
+            async def _sem(task):
+                async with semaphore:
+                    await self._execute_task(task)
+
+            await asyncio.gather(*[_sem(t) for t in tasks])
+
+    def _extract_model_groups(self, tasks: List[BatchTask]) -> List[tuple]:
+        groups = []
+        current_model = None
+        current_group = []
+        for task in tasks:
+            model = task.body.get("model", "")
+            if model != current_model:
+                if current_group:
+                    groups.append((current_model, current_group))
+                current_model = model
+                current_group = [task]
+            else:
+                current_group.append(task)
+        if current_group:
+            groups.append((current_model, current_group))
+        return groups
+
+    def _get_checkpoint_size_bytes(self, model_name: str) -> int:
+        """Return total checkpoint size in bytes by scanning the model directory.
+
+        Falls back to ``_estimated_model_sizes`` cache, then 0 if unavailable.
+        """
+        cached = self._estimated_model_sizes.get(model_name, 0)
+        if cached > 0:
+            return cached
+
+        if self.storage_manager is None:
+            return 0
+
+        model_dir = os.path.join(self.storage_manager.storage_path, model_name)
+        if not os.path.isdir(model_dir):
+            return 0
+
+        # Prefer sllm-store native format (tensor.data_*) if present; fall back
+        # to HuggingFace checkpoint files.  Never double-count both formats.
+        sllm_total = 0
+        hf_total = 0
+        for root, _dirs, files in os.walk(model_dir):
+            for fname in files:
+                if fname.startswith("tensor.data"):
+                    sllm_total += os.path.getsize(os.path.join(root, fname))
+                elif fname.endswith((".safetensors", ".bin", ".pt", ".gguf")):
+                    hf_total += os.path.getsize(os.path.join(root, fname))
+        total = sllm_total if sllm_total > 0 else hf_total
+
+        if total > 0:
+            self._estimated_model_sizes[model_name] = total
+        return total
+
+    # Baseline per-task inference time for a ~1B parameter model (seconds).
+    _BASE_TASK_TIME_S = 0.5
+    # Reference model size in bytes (~1B params in fp16 ≈ 2 GB).
+    _BASE_MODEL_BYTES = 2e9
+    # NVMe sequential read throughput for checkpoint I/O to pinned CPU memory (bytes/s).
+    # Raw NVMe bandwidth; used for the overlappable SSD→CPU portion only (Machine A in
+    # the flow-shop formulation). Actual sllm-store read times match size/bandwidth
+    # to within ~10% (Experiment 5, Table 6).
+    _NVME_READ_BPS = 3e9
+    # Non-overlappable GPU model-switch overhead: PCIe DMA + vLLM CUDA init + warmup (s).
+    # Measured: 32.6 s average on the test cluster with prefetch enabled (Experiment 2).
+    # This overhead is irreducible even when weights are pre-loaded into CPU pinned memory,
+    # because GPU memory allocation and vLLM engine warm-up cannot be parallelised with
+    # the previous group's inference. Must be included in all lane-load estimates and in
+    # the LPT rebalancing cost check (but NOT in Johnson's Rule, which only models the
+    # overlappable I/O phase).
+    _MODEL_SWITCH_OVERHEAD_S: float = 32.6
+
+    def _apply_johnsons_rule(
+        self,
+        groups: List[tuple],
+        model_load_time_s: float = 90.0,
+    ) -> List[tuple]:
+        """Reorder model groups using Johnson's Rule to minimise I/O idle.
+
+        Each model group is treated as a two-stage job:
+          - Stage 1 (I/O): load the model checkpoint from SSD to CPU
+          - Stage 2 (compute): run all tasks on GPU
+
+        I/O time is estimated from actual checkpoint size on disk (bytes / NVMe
+        throughput).  Compute time scales with both task count and model size
+        (larger models have proportionally longer per-token latency).
+
+        Johnson's Rule splits groups into:
+          S1: groups where compute >= load  (P >= I), sorted by I ascending
+          S2: groups where compute <  load  (P <  I), sorted by I descending
+        Then concatenates S1 + S2.
+        """
+        if len(groups) <= 1:
+            return groups
+
+        s1 = []  # P >= I
+        s2 = []  # P < I
+
+        for model_name, group_tasks in groups:
+            size_bytes = self._get_checkpoint_size_bytes(model_name)
+
+            if size_bytes > 0:
+                i_time = size_bytes / self._NVME_READ_BPS
+                # Scale per-task time linearly with model size
+                per_task = self._BASE_TASK_TIME_S * (size_bytes / self._BASE_MODEL_BYTES)
+            else:
+                i_time = model_load_time_s
+                per_task = self._BASE_TASK_TIME_S
+
+            p_time = len(group_tasks) * per_task
+
+            if p_time >= i_time:
+                s1.append((model_name, group_tasks, i_time, p_time))
+            else:
+                s2.append((model_name, group_tasks, i_time, p_time))
+
+        # S1: sort by load time ascending (shortest load first)
+        s1.sort(key=lambda x: x[2])
+        # S2: sort by compute time descending (longest compute first)
+        s2.sort(key=lambda x: x[3], reverse=True)
+
+        ordered = [(m, t) for m, t, _, _ in s1] + [(m, t) for m, t, _, _ in s2]
+
+        logger.info(
+            f"[JOHNSON] Reordered {len(groups)} model groups: "
+            f"S1={[(g[0], f'I={g[2]:.1f}s P={g[3]:.1f}s') for g in s1]} "
+            f"S2={[(g[0], f'I={g[2]:.1f}s P={g[3]:.1f}s') for g in s2]} -> "
+            f"{[g[0] for g in ordered]}"
+        )
+        return ordered
+
+    # ------------------------------------------------------------------ #
+    #  Task Execution                                                     #
+    # ------------------------------------------------------------------ #
+
+    async def _execute_task(self, task: BatchTask):
+        async with self._global_semaphore:
+            await self._execute_task_inner(task)
+
+    async def _execute_task_inner(self, task: BatchTask):
+        logger.info(f"Executing task {task.id} (Batch: {task.batch_id})")
+
+        started_at = datetime.now(timezone.utc).isoformat()
+
+        try:
+            model = task.body.get("model")
+            if not model:
+                raise ValueError("Model not specified in task body")
+
+            deployment_id = f"{model}:vllm"
+
+            if self.enable_model_grouping:
+                await self._ensure_deployment_ready(model)
+            else:
+                deployment = self.database.get_deployment_by_id(deployment_id)
+                available_gpus = await self._get_available_gpu_count()
+                tp = self._get_tp(model)
+                bc: dict | None = {"enforce_eager": True}
+                if tp > 1:
+                    bc["tensor_parallel_size"] = tp
+                # Each replica of a TP>1 model occupies `tp` GPUs, so the number
+                # of replicas that fit is floor(available_gpus / tp).
+                replicas = max(1, available_gpus // max(tp, 1))
+                if not deployment:
+                    try:
+                        self.database.create_deployment(
+                            model_name=model, backend="vllm",
+                            min_replicas=0, max_replicas=replicas,
+                            backend_config=bc,
+                        )
+                    except Exception as e:
+                        if "already exists" not in str(e):
+                            raise
+                elif deployment.max_replicas < 1:
+                    # Restore max_replicas after a previous _do_unload set it to 0
+                    logger.info(
+                        f"[SCALE-UP] {deployment_id}: max_replicas was "
+                        f"{deployment.max_replicas}, raising to {replicas}"
+                    )
+                    self.database.update_max_replicas(deployment_id, replicas)
+                    self.database.update_desired_replicas(deployment_id, replicas)
+
+            result = await self.router.handle_request(
+                payload=task.body,
+                path=task.url,
+                deployment_id=deployment_id
+            )
+
+            completed_at = datetime.now(timezone.utc).isoformat()
+            self.database.upsert_batch_task(
+                task_id=task.id,
+                batch_id=task.batch_id,
+                custom_id=task.custom_id,
+                method=task.method,
+                url=task.url,
+                body=task.body,
+                status="completed",
+                output=result,
+                started_at=started_at,
+                completed_at=completed_at
+            )
+            logger.info(f"Task {task.id} completed successfully")
+
+        except Exception as e:
+            logger.error(f"Task {task.id} failed: {e}")
+            completed_at = datetime.now(timezone.utc).isoformat()
+            self.database.upsert_batch_task(
+                task_id=task.id,
+                batch_id=task.batch_id,
+                custom_id=task.custom_id,
+                method=task.method,
+                url=task.url,
+                body=task.body,
+                status="failed",
+                output={"error": str(e)},
+                started_at=started_at,
+                completed_at=completed_at
+            )

--- a/sllm/cli/_cli_utils.py
+++ b/sllm/cli/_cli_utils.py
@@ -195,8 +195,11 @@ async def _run_head_node_v1beta():
         )
 
     # Initialize Router (single global instance)
-    router = init_router(database=db)
-    logger.info("Router initialized")
+    from sllm.router import RouterConfig
+    _buf_env = os.getenv("SLLM_ROUTER_BUFFER_SIZE")
+    router_config = RouterConfig(max_buffer_size=int(_buf_env)) if _buf_env else RouterConfig()
+    router = init_router(database=db, config=router_config)
+    logger.info(f"Router initialized with buffer_size={router_config.max_buffer_size}")
 
     # Initialize Autoscaler
     autoscaler = init_autoscaler(database=db)
@@ -238,6 +241,10 @@ async def _run_head_node_v1beta():
         )
         await storage_manager.recover_from_db()
         logger.info("StorageManager initialized")
+
+        # Expose StorageManager on app.state so the lifespan can wire it
+        # to the BatchScheduler for checkpoint prefetch
+        app.state.storage_manager = storage_manager
 
         # Start sllm-store on all worker nodes (expensive, do it eagerly)
         logger.info("Starting sllm-store on all worker nodes...")

--- a/sllm/command_builder.py
+++ b/sllm/command_builder.py
@@ -21,9 +21,26 @@ from typing import Tuple
 
 from sllm.database import Deployment
 
-VENV_VLLM = "/opt/venvs/vllm"
-VENV_SGLANG = "/opt/venvs/sglang"
-VENV_SLLM_STORE = "/opt/venvs/sllm-store"
+import os
+
+# Detect environment
+if os.path.exists("/opt/venvs"):
+    VENV_VLLM = "/opt/venvs/vllm"
+    VENV_SGLANG = "/opt/venvs/sglang"
+    VENV_SLLM_STORE = "/opt/venvs/sllm-store"
+else:
+    # Local development fallback
+    # Assuming standard structure: root/.venv
+    # We need absolute path for Pylet
+    _cwd = os.getcwd()
+    _venv_path = os.path.join(_cwd, ".venv")
+    if not os.path.exists(_venv_path):
+         # Try to find it if we are in a subdir
+         _venv_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.venv"))
+
+    VENV_VLLM = _venv_path
+    VENV_SGLANG = _venv_path
+    VENV_SLLM_STORE = _venv_path
 
 
 def build_vllm_command(
@@ -36,6 +53,7 @@ def build_vllm_command(
     gpu_memory_utilization = config.get("gpu_memory_utilization")
     dtype = config.get("dtype")
     trust_remote_code = config.get("trust_remote_code", False)
+    enforce_eager = config.get("enforce_eager", False)
 
     cmd_parts = [
         "vllm serve",
@@ -44,10 +62,15 @@ def build_vllm_command(
         "--port $PORT",
         "--host 0.0.0.0",
         f"--tensor-parallel-size {tp}",
+        "--enable-prefix-caching",
     ]
 
-    if max_model_len:
-        cmd_parts.append(f"--max-model-len {max_model_len}")
+    # Default max_model_len to 4096 if not specified.
+    # Many newer models (e.g. Qwen3-8B) default to 40960+ tokens,
+    # which exceeds single-GPU VRAM on A5000 (24GB).
+    if not max_model_len:
+        max_model_len = 4096
+    cmd_parts.append(f"--max-model-len {max_model_len}")
 
     if gpu_memory_utilization:
         cmd_parts.append(f"--gpu-memory-utilization {gpu_memory_utilization}")
@@ -57,6 +80,9 @@ def build_vllm_command(
 
     if trust_remote_code:
         cmd_parts.append("--trust-remote-code")
+
+    if enforce_eager:
+        cmd_parts.append("--enforce-eager")
 
     extra_args = config.get("extra_args", [])
     if extra_args:

--- a/sllm/database.py
+++ b/sllm/database.py
@@ -40,17 +40,15 @@ from sllm.logger import init_logger
 logger = init_logger(__name__)
 
 # Schema version for migrations
-SCHEMA_VERSION = 3
-
+SCHEMA_VERSION = 5
 
 @dataclass
 class Deployment:
     """Deployment configuration and scaling state.
-
+    
     A deployment represents a (model_name, backend) pair - the basic
     scheduling and control unit in ServerlessLLM.
     """
-
     id: str  # deployment_id: "meta-llama/Llama-3.1-8B:vllm"
     model_name: str  # HuggingFace model: "meta-llama/Llama-3.1-8B"
     backend: str  # "vllm" or "sglang"
@@ -72,24 +70,196 @@ class Deployment:
         """
         return f"{model_name}:{backend}"
 
-
 @dataclass
 class NodeStorage:
     """Storage info from sllm-store on a node."""
-
     node_name: str
     sllm_store_endpoint: Optional[str]
     cached_models: List[str]
     last_cache_update: str
 
+@dataclass
+class FileObject:
+    """A file uploaded by the user."""
+    id: str  # e.g., "file-..."
+    filename: str
+    bytes: int
+    purpose: str
+    created_at: str
+
+@dataclass
+class BatchJob:
+    """A batch job containing multiple tasks."""
+    id: str
+    status: str
+    metadata: Optional[Dict]
+    created_at: str
+    updated_at: str
+    input_file_id: Optional[str] = None
+
+
+@dataclass
+class BatchTask:
+    """A single task within a batch job."""
+
+    id: str  # UUID
+    batch_id: str
+    custom_id: str  # User-provided ID
+    method: str
+    url: str
+    body: Dict
+    status: str  # "pending", "completed", "failed"
+    output: Optional[Dict]
+    created_at: str
+    updated_at: str
+    # Metrics
+    started_at: Optional[str] = None      # When execution started (sent to vLLM)
+    completed_at: Optional[str] = None    # When execution finished
+
 
 class Database:
     """
     SQLite database for SLLM state persistence.
-
+    
     Thread-safe via connection-per-thread pattern.
     Uses WAL mode for better concurrent read performance.
     """
+
+    # -------------------------------------------------------------------------
+    # Batch Job Operations
+    # -------------------------------------------------------------------------
+
+    def update_batch_job_status(self, batch_id: str, status: str):
+        """Update batch job status."""
+        conn = self._get_connection()
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            "UPDATE batch_jobs SET status = ?, updated_at = ? WHERE id = ?",
+            (status, now, batch_id)
+        )
+        logger.debug(f"Updated batch {batch_id} status to {status}")
+
+    def update_batch_task_result(
+        self, task_id: str, status: str, output: Optional[Dict] = None
+    ):
+        """Update task status and output."""
+        conn = self._get_connection()
+        now = datetime.now(timezone.utc).isoformat()
+        output_json = json.dumps(output) if output else None
+        
+        conn.execute(
+            """
+            UPDATE batch_tasks 
+            SET status = ?, output = ?, updated_at = ? 
+            WHERE id = ?
+            """,
+            (status, output_json, now, task_id)
+        )
+
+    def get_pending_batch_ids(self) -> List[str]:
+        """Get IDs of all batches that are pending or in_progress."""
+        conn = self._get_connection()
+        rows = conn.execute(
+            "SELECT id FROM batch_jobs WHERE status IN ('pending', 'in_progress')"
+        ).fetchall()
+        return [row[0] for row in rows]
+
+    def create_batch_job(
+        self, batch_id: str, metadata: Optional[Dict] = None, input_file_id: Optional[str] = None
+    ) -> "BatchJob":
+        """Create a new batch job."""
+        conn = self._get_connection()
+        now = datetime.now(timezone.utc).isoformat()
+        metadata_json = json.dumps(metadata) if metadata else None
+
+        conn.execute(
+            "INSERT INTO batch_jobs (id, status, metadata, input_file_id, created_at, updated_at) "
+            "VALUES (?, 'pending', ?, ?, ?, ?)",
+            (batch_id, metadata_json, input_file_id, now, now),
+        )
+        return BatchJob(
+            id=batch_id,
+            status="pending",
+            metadata=metadata,
+            input_file_id=input_file_id,
+            created_at=now,
+            updated_at=now,
+        )
+
+    def get_batch_job(self, batch_id: str) -> Optional["BatchJob"]:
+        """Get a batch job by ID."""
+        conn = self._get_connection()
+        row = conn.execute(
+            "SELECT * FROM batch_jobs WHERE id = ?", (batch_id,)
+        ).fetchone()
+
+        if not row:
+            return None
+        return self._row_to_batch_job(row)
+
+    def _row_to_batch_job(self, row: sqlite3.Row) -> "BatchJob":
+        metadata = None
+        if "metadata" in row.keys() and row["metadata"]:
+            metadata = json.loads(row["metadata"])
+            
+        return BatchJob(
+            id=row["id"],
+            status=row["status"],
+            metadata=metadata,
+            input_file_id=row["input_file_id"] if "input_file_id" in row.keys() else None,
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    # -------------------------------------------------------------------------
+    # File Management Operations
+    # -------------------------------------------------------------------------
+
+    def create_file(self, file_id: str, filename: str, bytes_size: int, purpose: str) -> FileObject:
+        """Create a new file record."""
+        conn = self._get_connection()
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            "INSERT INTO files (id, filename, bytes, purpose, created_at) VALUES (?, ?, ?, ?, ?)",
+            (file_id, filename, bytes_size, purpose, now)
+        )
+        logger.info(f"Created file {file_id}")
+        return FileObject(
+            id=file_id,
+            filename=filename,
+            bytes=bytes_size,
+            purpose=purpose,
+            created_at=now
+        )
+
+    def get_file(self, file_id: str) -> Optional[FileObject]:
+        """Get file by ID."""
+        conn = self._get_connection()
+        row = conn.execute("SELECT * FROM files WHERE id = ?", (file_id,)).fetchone()
+        if not row:
+            return None
+        return FileObject(
+            id=row["id"],
+            filename=row["filename"],
+            bytes=row["bytes"],
+            purpose=row["purpose"],
+            created_at=row["created_at"]
+        )
+
+    def get_all_files(self) -> List[FileObject]:
+        """Get all files."""
+        conn = self._get_connection()
+        rows = conn.execute("SELECT * FROM files ORDER BY created_at DESC").fetchall()
+        return [
+            FileObject(
+                id=row["id"],
+                filename=row["filename"],
+                bytes=row["bytes"],
+                purpose=row["purpose"],
+                created_at=row["created_at"]
+            )
+            for row in rows
+        ]
 
     def __init__(self, db_path: str = "/var/lib/sllm/state.db"):
         self.db_path = Path(db_path)
@@ -149,6 +319,10 @@ class Database:
 
         if from_version < 3:
             self._migrate_v3(conn)
+        if from_version < 4:
+            self._migrate_v4(conn)
+        if from_version < 5:
+            self._migrate_v5(conn)
 
         # Update schema version
         conn.execute("DELETE FROM schema_version")
@@ -211,6 +385,66 @@ class Database:
         """)
 
         logger.info("Created v3 schema with deployment terminology")
+
+    def _migrate_v4(self, conn: sqlite3.Connection):
+        """Create v4 schema with batch job support (Squashed v4-v6)."""
+        # Batch Jobs table
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS batch_jobs (
+                id TEXT PRIMARY KEY,
+                status TEXT NOT NULL DEFAULT 'pending',
+                metadata TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+        """)
+
+        # Batch Tasks table
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS batch_tasks (
+                id TEXT PRIMARY KEY,
+                batch_id TEXT NOT NULL,
+                custom_id TEXT NOT NULL,
+                method TEXT NOT NULL,
+                url TEXT NOT NULL,
+                body TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                output TEXT,
+                started_at TEXT,
+                completed_at TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY(batch_id) REFERENCES batch_jobs(id)
+            )
+        """)
+
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_batch_tasks_batch_id
+            ON batch_tasks(batch_id)
+        """)
+
+        logger.info("Created v4 schema (Batch Support)")
+
+    def _migrate_v5(self, conn: sqlite3.Connection):
+        """Create v5 schema with file management support."""
+        # Files table
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS files (
+                id TEXT PRIMARY KEY,
+                filename TEXT NOT NULL,
+                bytes INTEGER NOT NULL,
+                purpose TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+        """)
+
+        # Alter batch_jobs to add input_file_id (if not exists)
+        try:
+            conn.execute("ALTER TABLE batch_jobs ADD COLUMN input_file_id TEXT")
+        except sqlite3.OperationalError:
+            pass # Column already exists, which is fine
+
+        logger.info("Created v5 schema (File Support)")
 
     # -------------------------------------------------------------------------
     # Deployment CRUD Operations
@@ -297,6 +531,22 @@ class Database:
         ).fetchall()
         return [self._row_to_deployment(row) for row in rows]
 
+    def update_max_replicas(self, deployment_id: str, max_replicas: int) -> bool:
+        """Update max_replicas for a deployment. Returns True if updated."""
+        conn = self._get_connection()
+        now = datetime.now(timezone.utc).isoformat()
+
+        cursor = conn.execute(
+            """
+            UPDATE deployments
+            SET max_replicas = ?, updated_at = ?
+            WHERE id = ? AND status = 'active'
+            """,
+            (max_replicas, now, deployment_id),
+        )
+
+        return cursor.rowcount > 0
+
     def update_desired_replicas(self, deployment_id: str, desired: int) -> bool:
         """Update desired_replicas for a deployment. Returns True if updated."""
         conn = self._get_connection()
@@ -365,6 +615,178 @@ class Database:
             backend_config=backend_config,
             created_at=row["created_at"],
             updated_at=row["updated_at"],
+        )
+
+    # -------------------------------------------------------------------------
+    # Batch Job Operations
+    # -------------------------------------------------------------------------
+
+    # Job methods defined above...
+
+    def create_batch_task(
+        self,
+        task_id: str,
+        batch_id: str,
+        custom_id: str,
+        method: str,
+        url: str,
+        body: Dict,
+    ) -> "BatchTask":
+        """Create a new batch task."""
+        conn = self._get_connection()
+        now = datetime.now(timezone.utc).isoformat()
+        body_json = json.dumps(body)
+
+        conn.execute(
+            """
+            INSERT INTO batch_tasks (
+                id, batch_id, custom_id, method, url, body, status,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+            """,
+            (
+                task_id,
+                batch_id,
+                custom_id,
+                method,
+                url,
+                body_json,
+                now,
+                now,
+            ),
+        )
+        return BatchTask(
+            id=task_id,
+            batch_id=batch_id,
+            custom_id=custom_id,
+            method=method,
+            url=url,
+            body=body,
+            status="pending",
+            output=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+    def create_batch_tasks_bulk(
+        self,
+        tasks: List[Dict],
+        batch_id: str,
+    ) -> int:
+        """Bulk-insert batch tasks in a single transaction.
+
+        Args:
+            tasks: List of dicts with keys: task_id, custom_id, method, url, body
+            batch_id: Parent batch job ID
+
+        Returns:
+            Number of tasks inserted.
+        """
+        conn = self._get_connection()
+        now = datetime.now(timezone.utc).isoformat()
+
+        rows = [
+            (
+                t["task_id"],
+                batch_id,
+                t["custom_id"],
+                t["method"],
+                t["url"],
+                json.dumps(t["body"]),
+                now,
+                now,
+            )
+            for t in tasks
+        ]
+
+        conn.execute("BEGIN")
+        try:
+            conn.executemany(
+                """
+                INSERT INTO batch_tasks (
+                    id, batch_id, custom_id, method, url, body, status,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+                """,
+                rows,
+            )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+        return len(rows)
+
+    def upsert_batch_task(
+        self,
+        task_id: str,
+        batch_id: str,
+        custom_id: str,
+        method: str,
+        url: str,
+        body: Dict,
+        status: str = "pending",
+        output: Optional[Dict] = None,
+        started_at: Optional[str] = None,
+        completed_at: Optional[str] = None,
+    ):
+        """Insert or update a batch task with metrics support."""
+        conn = self._get_connection()
+        now = datetime.now(timezone.utc).isoformat()
+        body_json = json.dumps(body)
+        output_json = json.dumps(output) if output else None
+
+        conn.execute(
+            """
+            INSERT INTO batch_tasks (
+                id, batch_id, custom_id, method, url, body, status,
+                output, started_at, completed_at, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                status = excluded.status,
+                output = excluded.output,
+                started_at = COALESCE(excluded.started_at, batch_tasks.started_at),
+                completed_at = COALESCE(excluded.completed_at, batch_tasks.completed_at),
+                updated_at = excluded.updated_at
+            """,
+            (
+                task_id,
+                batch_id,
+                custom_id,
+                method,
+                url,
+                body_json,
+                status,
+                output_json,
+                started_at,
+                completed_at,
+                now,
+                now,
+            ),
+        )
+
+    def get_batch_tasks(self, batch_id: str) -> List["BatchTask"]:
+        """Get all tasks for a batch job."""
+        conn = self._get_connection()
+        rows = conn.execute(
+            "SELECT * FROM batch_tasks WHERE batch_id = ?", (batch_id,)
+        ).fetchall()
+        return [self._row_to_batch_task(row) for row in rows]
+
+    def _row_to_batch_task(self, row: sqlite3.Row) -> "BatchTask":
+        return BatchTask(
+            id=row["id"],
+            batch_id=row["batch_id"],
+            custom_id=row["custom_id"],
+            method=row["method"],
+            url=row["url"],
+            body=json.loads(row["body"]),
+            status=row["status"],
+            output=json.loads(row["output"]) if row["output"] else None,
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            started_at=row["started_at"] if "started_at" in row.keys() else None,
+            completed_at=row["completed_at"] if "completed_at" in row.keys() else None,
         )
 
     # -------------------------------------------------------------------------
@@ -567,6 +989,8 @@ class Database:
         conn.execute("DELETE FROM deployments")
         conn.execute("DELETE FROM node_storage")
         conn.execute("DELETE FROM deployment_endpoints")
+        conn.execute("DELETE FROM batch_jobs")
+        conn.execute("DELETE FROM batch_tasks")
         logger.warning("Database reset - all data deleted")
 
 

--- a/sllm/reconciler.py
+++ b/sllm/reconciler.py
@@ -477,15 +477,23 @@ class Reconciler:
             deployment.id
         )
 
-        if not instances:
+        # Treat cancelled/failed instances as already gone — pylet never
+        # removes them from its registry, so we must filter them out to
+        # avoid looping forever trying to cancel already-cancelled instances.
+        active_instances = [
+            inst for inst in instances
+            if inst.status not in ("CANCELLED", "FAILED", "UNKNOWN", "COMPLETED")
+        ]
+
+        if not active_instances:
             # All instances gone - remove endpoints and delete from database
             self.database.remove_deployment_endpoints(deployment.id)
             self.database.delete_deployment(deployment.id)
             logger.info(f"Completed deletion of {deployment.id}")
             return
 
-        # Cancel remaining instances
-        for inst in instances:
+        # Cancel remaining active instances
+        for inst in active_instances:
             await self._cleanup_instance(deployment.id, inst)
 
 

--- a/sllm/router.py
+++ b/sllm/router.py
@@ -57,9 +57,9 @@ logger = init_logger(__name__)
 class RouterConfig:
     """Router configuration."""
 
-    max_buffer_size: int = 10
-    cold_start_timeout: float = 120.0
-    request_timeout: float = 300.0
+    max_buffer_size: int = 100
+    cold_start_timeout: float = 600.0
+    request_timeout: float = 600.0
     retry_failed_endpoint: bool = True
 
 
@@ -352,20 +352,28 @@ class Router:
                             deployment_id
                         )
                         if endpoints:
-                            try:
-                                request = buffer.get_nowait()
-                                endpoint = self._select_next_endpoint(
-                                    deployment_id, endpoints
-                                )
+                            # Drain as many buffered requests as possible
+                            # in one pass (up to number of endpoints for
+                            # basic load spreading)
+                            drained = 0
+                            while not buffer.empty():
+                                try:
+                                    request = buffer.get_nowait()
+                                    endpoint = self._select_next_endpoint(
+                                        deployment_id, endpoints
+                                    )
+                                    if not request.endpoint_future.done():
+                                        request.endpoint_future.set_result(
+                                            endpoint
+                                        )
+                                    drained += 1
+                                except asyncio.QueueEmpty:
+                                    break
+                            if drained:
                                 logger.info(
-                                    f"[{deployment_id}] Endpoint available, "
-                                    f"unblocking request to {endpoint}"
+                                    f"[{deployment_id}] Drained {drained} "
+                                    f"buffered requests"
                                 )
-                                # Signal endpoint availability (caller forwards)
-                                if not request.endpoint_future.done():
-                                    request.endpoint_future.set_result(endpoint)
-                            except asyncio.QueueEmpty:
-                                pass
 
                 await asyncio.sleep(0.1)
 

--- a/sllm/storage_manager.py
+++ b/sllm/storage_manager.py
@@ -28,6 +28,7 @@ Responsibilities:
 """
 
 import asyncio
+import os
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Set
 
@@ -209,12 +210,15 @@ class StorageManager:
 
         # Start sllm-store instance
         try:
+            mem_pool = os.environ.get("SLLM_STORE_MEM_POOL_SIZE", "")
+            mem_pool_arg = f"--mem-pool-size {mem_pool} " if mem_pool else ""
             command = (
                 f"sllm-store start "
                 f"--port $PORT "
                 f"--storage-path {self.storage_path} "
-                f"--host 0.0.0.0"
-            )
+                f"--host 0.0.0.0 "
+                f"{mem_pool_arg}"
+            ).strip()
 
             instance = await self.pylet_client.submit(
                 command=command,
@@ -421,6 +425,281 @@ class StorageManager:
         )
 
         return best_node
+
+    # -------------------------------------------------------------------------
+    # Checkpoint Prefetch
+    # -------------------------------------------------------------------------
+
+    async def prefetch_to_cpu(self, model_name: str, node_name: str = None) -> bool:
+        """Prefetch model weights into system memory while the current model runs.
+
+        Two-stage prefetch for reliability:
+        1. sllm-store gRPC LoadModelAsync: loads weights into the pinned memory
+           pool (cudaHostRegister) on the sllm-store server, enabling fast
+           DMA-based GPU transfers when the serverless_llm loader is used.
+        2. HF-cache page-warm: reads the HuggingFace safetensors files into the
+           OS page cache so that vLLM's default loader finds them already in RAM
+           instead of fetching from SSD.  This produces a measurable reduction in
+           model-switch latency because the SSD I/O is overlapped with the
+           previous group's inference rather than serialised on the critical path.
+
+        Args:
+            model_name: Model name (e.g. "Qwen/Qwen3-8B").
+            node_name:  Target node. If None, uses first available node.
+
+        Returns:
+            True if at least one prefetch path succeeded, False otherwise.
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            # ── HF-cache page-warm (synchronous read, ~4-5 s for 8B) ──
+            # vLLM uses load_format=auto, loading safetensors from
+            # ~/.cache/huggingface/hub.  Reading those files here warms the
+            # OS page cache so that vLLM's weight-load step at model-switch
+            # time hits RAM instead of SSD.  We use HF-cache warm exclusively
+            # rather than sllm-store gRPC to avoid double NVMe I/O (sllm-store
+            # reads tensor.data from the same SSD, which would saturate
+            # bandwidth and defeat the purpose).
+            hf_result = await loop.run_in_executor(
+                None,
+                self._prefetch_hf_cache,
+                model_name,
+            )
+            if hf_result:
+                return True
+
+            # ── Fallback: sllm-store pinned-memory prefetch ──
+            # Used if no HF cache is present (e.g., custom model or offline).
+            endpoint = None
+            if node_name:
+                endpoint = await self.get_store_endpoint(node_name)
+            if not endpoint:
+                for ep in self._store_endpoints.values():
+                    endpoint = ep
+                    break
+
+            if endpoint:
+                return await loop.run_in_executor(
+                    None,
+                    self._prefetch_via_store,
+                    model_name,
+                    endpoint,
+                )
+
+            # Last resort: raw read of sllm-store checkpoint files
+            logger.warning(
+                f"[PREFETCH] No HF cache or sllm-store endpoint, "
+                f"falling back to raw file read for {model_name}"
+            )
+            return await loop.run_in_executor(
+                None,
+                self._prefetch_raw_read,
+                model_name,
+            )
+        except Exception as e:
+            logger.error(f"[PREFETCH] Error prefetching {model_name}: {e}")
+            return False
+
+    # --- synchronous helpers (executed in thread-pool) ----------------------
+
+    @staticmethod
+    def _prefetch_via_store(model_name: str, endpoint: str) -> bool:
+        """Load model into pinned CPU memory via sllm-store gRPC."""
+        import time
+
+        t0 = time.monotonic()
+        logger.info(
+            f"[PREFETCH] Loading {model_name} into pinned memory "
+            f"via sllm-store at {endpoint}"
+        )
+
+        try:
+            from sllm_store.client import SllmStoreClient
+
+            client = SllmStoreClient(server_address=endpoint)
+            response = client.load_into_cpu(model_name)
+
+            elapsed = time.monotonic() - t0
+            if response is False:
+                logger.error(
+                    f"[PREFETCH] sllm-store failed to load {model_name} "
+                    f"after {elapsed:.1f}s"
+                )
+                return False
+
+            logger.info(
+                f"[PREFETCH] {model_name} loaded into pinned memory "
+                f"via sllm-store ({elapsed:.1f}s)"
+            )
+            return True
+
+        except Exception as e:
+            elapsed = time.monotonic() - t0
+            logger.error(
+                f"[PREFETCH] sllm-store prefetch failed for {model_name} "
+                f"after {elapsed:.1f}s: {e}"
+            )
+            return False
+
+    async def unload_from_cpu(self, model_name: str) -> bool:
+        """Unload model from sllm-store's pinned CPU memory.
+
+        Used by the batch scheduler to proactively free pool space after a
+        model group finishes and no future tasks need the model.
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            endpoint = None
+            for ep in self._store_endpoints.values():
+                endpoint = ep
+                break
+
+            if not endpoint:
+                logger.warning(
+                    f"[UNLOAD] No sllm-store endpoint available, "
+                    f"cannot unload {model_name}"
+                )
+                return False
+
+            result = await loop.run_in_executor(
+                None,
+                self._unload_via_store,
+                model_name,
+                endpoint,
+            )
+            return result
+        except Exception as e:
+            logger.error(f"[UNLOAD] Error unloading {model_name}: {e}")
+            return False
+
+    @staticmethod
+    def _unload_via_store(model_name: str, endpoint: str) -> bool:
+        """Unload model from pinned CPU memory via sllm-store gRPC."""
+        try:
+            from sllm_store.client import SllmStoreClient
+
+            client = SllmStoreClient(server_address=endpoint)
+            response = client.unload_from_cpu(model_name)
+
+            if response is False:
+                logger.error(f"[UNLOAD] sllm-store failed to unload {model_name}")
+                return False
+
+            logger.info(f"[UNLOAD] {model_name} removed from pinned memory")
+            return True
+        except Exception as e:
+            logger.error(f"[UNLOAD] sllm-store unload failed for {model_name}: {e}")
+            return False
+
+    def _prefetch_raw_read(self, model_name: str) -> bool:
+        """Fallback: read weight files into OS page cache via raw I/O."""
+        import os
+        import time
+
+        t0 = time.monotonic()
+        model_dir = os.path.join(self.storage_path, model_name)
+        logger.info(f"[PREFETCH] Raw-reading weight files from {model_dir}")
+
+        if not os.path.isdir(model_dir):
+            logger.error(f"[PREFETCH] Model directory not found: {model_dir}")
+            return False
+
+        try:
+            total_bytes = 0
+            for fname in os.listdir(model_dir):
+                if fname.endswith((".safetensors", ".bin")):
+                    fpath = os.path.join(model_dir, fname)
+                    with open(fpath, "rb") as f:
+                        while chunk := f.read(64 * 1024 * 1024):  # 64 MB
+                            total_bytes += len(chunk)
+
+            elapsed = time.monotonic() - t0
+            total_gb = total_bytes / (1024 ** 3)
+            logger.info(
+                f"[PREFETCH] Raw-read {model_name} into page cache "
+                f"({total_gb:.1f} GB, {elapsed:.1f}s)"
+            )
+            return True
+
+        except Exception as e:
+            elapsed = time.monotonic() - t0
+            logger.error(
+                f"[PREFETCH] Raw-read failed for {model_name} "
+                f"after {elapsed:.1f}s: {e}"
+            )
+            return False
+
+    @staticmethod
+    def _prefetch_hf_cache(model_name: str) -> bool:
+        """Warm OS page cache for model's HuggingFace checkpoint files.
+
+        vLLM uses load_format=auto by default, which reads safetensors shards
+        from ~/.cache/huggingface/hub/.  Reading those files here, while the
+        previous model group is still executing, moves the SSD→RAM transfer
+        off the critical path: when vLLM loads the model at switch time it
+        finds the data already in RAM (page cache hit, <0.1 s) instead of
+        reading from SSD (~4-5 s for an 8B model).
+
+        Eviction via posix_fadvise(DONTNEED) must be called before each
+        benchmark run (see evict_models_page_cache in exp_common.py) to ensure
+        this read represents a genuine cold-disk access.
+        """
+        import os
+        import time
+
+        t0 = time.monotonic()
+        # Locate HF snapshot directory: Qwen/Qwen3-8B → models--Qwen--Qwen3-8B
+        hf_cache = os.path.expanduser("~/.cache/huggingface/hub")
+        hf_dir = "models--" + model_name.replace("/", "--")
+        snapshots_dir = os.path.join(hf_cache, hf_dir, "snapshots")
+
+        if not os.path.isdir(snapshots_dir):
+            logger.warning(
+                f"[PREFETCH-HF] No HF cache found for {model_name} "
+                f"at {snapshots_dir} — skipping page-warm"
+            )
+            return False
+
+        # Use the first (newest) snapshot directory
+        snapshots = sorted(os.listdir(snapshots_dir), reverse=True)
+        if not snapshots:
+            return False
+        snap_path = os.path.join(snapshots_dir, snapshots[0])
+
+        total_bytes = 0
+        try:
+            weight_files = sorted(
+                f for f in os.listdir(snap_path)
+                if f.endswith((".safetensors", ".bin", ".pt"))
+            )
+            if not weight_files:
+                logger.warning(
+                    f"[PREFETCH-HF] No weight files in {snap_path}"
+                )
+                return False
+
+            for fname in weight_files:
+                fpath = os.path.join(snap_path, fname)
+                with open(fpath, "rb") as f:
+                    while chunk := f.read(64 * 1024 * 1024):  # 64 MB chunks
+                        total_bytes += len(chunk)
+
+            elapsed = time.monotonic() - t0
+            total_gb = total_bytes / (1024 ** 3)
+            logger.info(
+                f"[PREFETCH-HF] {model_name} page-warmed "
+                f"({total_gb:.1f} GB in {elapsed:.1f}s, "
+                f"{total_gb / elapsed:.1f} GB/s)"
+            )
+            return True
+
+        except Exception as e:
+            elapsed = time.monotonic() - t0
+            logger.error(
+                f"[PREFETCH-HF] Failed for {model_name} "
+                f"after {elapsed:.1f}s: {e}"
+            )
+            return False
 
     # -------------------------------------------------------------------------
     # Utilities

--- a/tests/unit/test_batch_scheduler.py
+++ b/tests/unit/test_batch_scheduler.py
@@ -1,0 +1,939 @@
+"""
+Tests for BatchScheduler: model grouping, Johnson's Rule, prefetch,
+proactive unloading, GPU rebalancing, and autoscaler integration.
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+from sllm.database import BatchTask
+from sllm.batch_scheduler import BatchScheduler
+
+
+# ============================================================================ #
+# Helpers
+# ============================================================================ #
+
+
+def make_task(
+    task_id: str = "t1",
+    batch_id: str = "b1",
+    model: str = "Qwen-7B",
+    prompt: str = "Hello",
+    status: str = "pending",
+) -> BatchTask:
+    return BatchTask(
+        id=task_id,
+        batch_id=batch_id,
+        custom_id=f"custom-{task_id}",
+        method="POST",
+        url="/v1/chat/completions",
+        body={
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 100,
+        },
+        status=status,
+        output=None,
+        created_at="2025-01-01T00:00:00",
+        updated_at="2025-01-01T00:00:00",
+    )
+
+
+def make_mock_database():
+    db = MagicMock()
+    db.get_pending_batch_ids.return_value = []
+    db.get_batch_tasks.return_value = []
+    db.get_batch_job.return_value = None
+    db.get_deployment_by_id.return_value = None
+    db.update_batch_job_status = MagicMock()
+    db.upsert_batch_task = MagicMock()
+    db.create_deployment = MagicMock()
+    db.get_deployment_endpoints.return_value = ["localhost:8000"]
+    return db
+
+
+def make_mock_router():
+    router = MagicMock()
+    router.config = MagicMock()
+    router.config.max_buffer_size = 100
+    router.handle_request = AsyncMock(return_value={"choices": [{"text": "ok"}]})
+    return router
+
+
+def make_scheduler(**kwargs):
+    db = kwargs.get("database", make_mock_database())
+    router = kwargs.get("router", make_mock_router())
+    s = BatchScheduler(database=db, router=router)
+    return s, db, router
+
+
+# ============================================================================ #
+# Model Grouping & Extraction
+# ============================================================================ #
+
+
+class TestModelGroupExtraction:
+    """Verify _extract_model_groups produces correct groups."""
+
+    def test_single_model(self):
+        s, _, _ = make_scheduler()
+        tasks = [make_task(f"t{i}", model="A") for i in range(5)]
+        groups = s._extract_model_groups(tasks)
+        assert len(groups) == 1
+        assert groups[0][0] == "A"
+        assert len(groups[0][1]) == 5
+
+    def test_multiple_models_sorted(self):
+        s, _, _ = make_scheduler()
+        tasks = [
+            make_task("t1", model="A"),
+            make_task("t2", model="A"),
+            make_task("t3", model="B"),
+            make_task("t4", model="B"),
+            make_task("t5", model="B"),
+        ]
+        groups = s._extract_model_groups(tasks)
+        assert len(groups) == 2
+        assert groups[0] == ("A", tasks[:2])
+        assert groups[1] == ("B", tasks[2:])
+
+    def test_interleaved_creates_separate_groups(self):
+        """Unsorted input creates multiple groups for same model."""
+        s, _, _ = make_scheduler()
+        tasks = [
+            make_task("t1", model="A"),
+            make_task("t2", model="B"),
+            make_task("t3", model="A"),
+        ]
+        groups = s._extract_model_groups(tasks)
+        assert len(groups) == 3
+
+    def test_empty_tasks(self):
+        s, _, _ = make_scheduler()
+        groups = s._extract_model_groups([])
+        assert groups == []
+
+
+# ============================================================================ #
+# Johnson's Rule
+# ============================================================================ #
+
+
+class TestJohnsonsRule:
+    """Verify Johnson's Rule ordering."""
+
+    def test_single_group_unchanged(self):
+        s, _, _ = make_scheduler()
+        groups = [("A", [make_task("t1", model="A")])]
+        result = s._apply_johnsons_rule(groups)
+        assert len(result) == 1
+        assert result[0][0] == "A"
+
+    def test_two_groups_ordering(self):
+        """With default estimates (no checkpoint sizes), all groups use
+        fallback model_load_time_s=90s for I/O. Groups with more tasks
+        (higher P) go into S1, sorted by I ascending."""
+        s, _, _ = make_scheduler()
+        # Group A: 200 tasks (P >> I) → S1
+        # Group B: 1 task (P < I) → S2
+        groups = [
+            ("A", [make_task(f"a{i}", model="A") for i in range(200)]),
+            ("B", [make_task("b0", model="B")]),
+        ]
+        result = s._apply_johnsons_rule(groups)
+        # S1=[A], S2=[B] → order: A, B
+        assert result[0][0] == "A"
+        assert result[1][0] == "B"
+
+    def test_s2_sorted_descending(self):
+        """S2 groups (P < I) should be sorted by I descending."""
+        s, _, _ = make_scheduler()
+        # All groups have 1 task → P = 0.5s, I = 90s → all in S2
+        # With no checkpoint sizes, all have same I, so order is stable
+        groups = [
+            ("A", [make_task("a0", model="A")]),
+            ("B", [make_task("b0", model="B")]),
+            ("C", [make_task("c0", model="C")]),
+        ]
+        result = s._apply_johnsons_rule(groups)
+        assert len(result) == 3
+
+    def test_empty_groups(self):
+        s, _, _ = make_scheduler()
+        result = s._apply_johnsons_rule([])
+        assert result == []
+
+
+# ============================================================================ #
+# GPU Assignment & Rebalancing
+# ============================================================================ #
+
+
+class TestGPUAssignment:
+    """Verify _assign_groups_to_gpus with greedy + rebalancing."""
+
+    def test_single_gpu_returns_all(self):
+        s, _, _ = make_scheduler()
+        groups = [
+            ("A", [make_task(f"a{i}", model="A") for i in range(10)]),
+            ("B", [make_task(f"b{i}", model="B") for i in range(5)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 1)
+        assert len(result) == 1
+        assert result[0] == groups
+
+    def test_two_gpus_balanced(self):
+        """Two equal groups should go to separate GPUs."""
+        s, _, _ = make_scheduler()
+        groups = [
+            ("A", [make_task(f"a{i}", model="A") for i in range(10)]),
+            ("B", [make_task(f"b{i}", model="B") for i in range(10)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 2)
+        assert len(result) == 2
+        # Each GPU should have one group
+        assert len(result[0]) >= 1
+        assert len(result[1]) >= 1
+
+    def test_rebalancing_splits_heavy_group(self):
+        """One very heavy group + one light group on 2 GPUs should trigger rebalancing."""
+        s, _, _ = make_scheduler()
+        # A: 100 tasks, B: 2 tasks — huge imbalance
+        groups = [
+            ("A", [make_task(f"a{i}", model="A") for i in range(100)]),
+            ("B", [make_task(f"b{i}", model="B") for i in range(2)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 2)
+        # After rebalancing, model A should be split across both GPUs
+        all_a_tasks = []
+        for queue in result:
+            for model, tasks in queue:
+                if model == "A":
+                    all_a_tasks.extend(tasks)
+        assert len(all_a_tasks) == 100  # No tasks lost
+
+        # Both GPUs should have work
+        for queue in result:
+            total_tasks = sum(len(t) for _, t in queue)
+            assert total_tasks > 0
+
+    def test_rebalancing_preserves_all_tasks(self):
+        """Rebalancing must never lose or duplicate tasks."""
+        s, _, _ = make_scheduler()
+        groups = [
+            ("A", [make_task(f"a{i}", model="A") for i in range(50)]),
+            ("B", [make_task(f"b{i}", model="B") for i in range(30)]),
+            ("C", [make_task(f"c{i}", model="C") for i in range(20)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 3)
+
+        # Count all tasks across all GPUs
+        all_task_ids = set()
+        for queue in result:
+            for _, tasks in queue:
+                for t in tasks:
+                    all_task_ids.add(t.id)
+        assert len(all_task_ids) == 100
+
+    def test_single_task_group_not_split(self):
+        """A group with 1 task cannot be split."""
+        s, _, _ = make_scheduler()
+        groups = [
+            ("A", [make_task("a0", model="A")]),
+            ("B", [make_task(f"b{i}", model="B") for i in range(50)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 2)
+        # A should remain intact (1 task)
+        a_counts = []
+        for queue in result:
+            for model, tasks in queue:
+                if model == "A":
+                    a_counts.append(len(tasks))
+        assert 1 in a_counts
+
+    def test_tp_group_gets_own_lane(self):
+        """TP>1 model should get a dedicated lane."""
+        s, _, _ = make_scheduler()
+        s.set_tp_config({"BigModel": 4})
+        groups = [
+            ("BigModel", [make_task(f"big{i}", model="BigModel") for i in range(10)]),
+            ("SmallA", [make_task(f"sa{i}", model="SmallA") for i in range(10)]),
+            ("SmallB", [make_task(f"sb{i}", model="SmallB") for i in range(10)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 8)
+        # BigModel should be alone on its lane (not mixed with TP=1 models)
+        for queue in result:
+            models_in_queue = [m for m, _ in queue]
+            if "BigModel" in models_in_queue:
+                assert models_in_queue == ["BigModel"]
+                break
+
+    def test_tp_group_not_split_by_rebalancing(self):
+        """TP groups should not be split across lanes by the rebalancing loop."""
+        s, _, _ = make_scheduler()
+        s.set_tp_config({"BigModel": 4})
+        groups = [
+            ("BigModel", [make_task(f"big{i}", model="BigModel") for i in range(200)]),
+            ("Small", [make_task(f"s{i}", model="Small") for i in range(5)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 8)
+        # All BigModel tasks on exactly one lane
+        big_tasks_per_lane = {}
+        for qi, queue in enumerate(result):
+            for model, tasks in queue:
+                if model == "BigModel":
+                    big_tasks_per_lane[qi] = big_tasks_per_lane.get(qi, 0) + len(tasks)
+        assert len(big_tasks_per_lane) == 1
+        assert list(big_tasks_per_lane.values())[0] == 200
+
+    def test_two_tp2_models_parallel_lanes(self):
+        """Two TP=2 models on 4+ GPUs should get separate parallel lanes."""
+        s, _, _ = make_scheduler()
+        s.set_tp_config({"ModelA": 2, "ModelB": 2})
+        groups = [
+            ("ModelA", [make_task(f"a{i}", model="ModelA") for i in range(10)]),
+            ("ModelB", [make_task(f"b{i}", model="ModelB") for i in range(10)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 4)
+        # Each TP=2 model should be on its own lane (2 TP lanes)
+        lane_models = [[m for m, _ in q] for q in result if q]
+        a_lanes = [i for i, ms in enumerate(lane_models) if "ModelA" in ms]
+        b_lanes = [i for i, ms in enumerate(lane_models) if "ModelB" in ms]
+        assert len(a_lanes) == 1
+        assert len(b_lanes) == 1
+        assert a_lanes[0] != b_lanes[0]  # Different lanes → parallel
+
+    def test_two_tp2_models_shared_lane_insufficient_gpus(self):
+        """Two TP=2 models on 3 GPUs with a TP=1 model → must share a lane."""
+        s, _, _ = make_scheduler()
+        s.set_tp_config({"ModelA": 2, "ModelB": 2})
+        groups = [
+            ("ModelA", [make_task(f"a{i}", model="ModelA") for i in range(10)]),
+            ("ModelB", [make_task(f"b{i}", model="ModelB") for i in range(10)]),
+            ("SmallC", [make_task(f"c{i}", model="SmallC") for i in range(5)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 3)
+        # Both TP=2 models should share one lane (budget=2, 1 GPU left for SmallC)
+        for queue in result:
+            models_in_queue = [m for m, _ in queue]
+            if "ModelA" in models_in_queue and "ModelB" in models_in_queue:
+                break
+        else:
+            pytest.fail("ModelA and ModelB should share a lane on 3 GPUs")
+
+    def test_mixed_tp_sizes(self):
+        """TP=4 + TP=2 on 8 GPUs → separate lanes (budget 4+2), 2 TP=1 lanes."""
+        s, _, _ = make_scheduler()
+        s.set_tp_config({"Big": 4, "Med": 2})
+        groups = [
+            ("Big", [make_task(f"big{i}", model="Big") for i in range(10)]),
+            ("Med", [make_task(f"med{i}", model="Med") for i in range(10)]),
+            ("SmA", [make_task(f"a{i}", model="SmA") for i in range(10)]),
+            ("SmB", [make_task(f"b{i}", model="SmB") for i in range(10)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 8)
+        # Big and Med should be on separate lanes
+        big_lane = med_lane = None
+        for i, queue in enumerate(result):
+            for m, _ in queue:
+                if m == "Big":
+                    big_lane = i
+                if m == "Med":
+                    med_lane = i
+        assert big_lane is not None and med_lane is not None
+        assert big_lane != med_lane
+
+    def test_tp_reserve_for_single_groups(self):
+        """TP lanes should reserve at least 1 GPU for TP=1 groups."""
+        s, _, _ = make_scheduler()
+        s.set_tp_config({"ModelA": 2})
+        groups = [
+            ("ModelA", [make_task(f"a{i}", model="ModelA") for i in range(10)]),
+            ("SmallB", [make_task(f"b{i}", model="SmallB") for i in range(5)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 3)
+        # SmallB should get its own lane (not starved)
+        small_found = False
+        for queue in result:
+            for m, _ in queue:
+                if m == "SmallB":
+                    small_found = True
+        assert small_found
+
+    def test_rebalancing_not_blocked_by_tp(self):
+        """Rebalancing of TP=1 lanes should work even when TP lanes exist."""
+        s, _, _ = make_scheduler()
+        s.set_tp_config({"BigTP": 2})
+        # Use enough tasks so compute gap exceeds I/O cost of splitting.
+        # Default model_load_time = 90s, per_task ~0.5s, so we need
+        # enough imbalance: Heavy(500)=250s vs Light(5)=2.5s, gap > 90s.
+        groups = [
+            ("BigTP", [make_task(f"tp{i}", model="BigTP") for i in range(5)]),
+            ("Heavy", [make_task(f"h{i}", model="Heavy") for i in range(500)]),
+            ("Light", [make_task(f"l{i}", model="Light") for i in range(5)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 4)
+        # Heavy group should be split across TP=1 lanes (rebalancing works)
+        heavy_count = 0
+        heavy_lanes = 0
+        for queue in result:
+            for m, tasks in queue:
+                if m == "Heavy":
+                    heavy_count += len(tasks)
+                    heavy_lanes += 1
+        assert heavy_count == 500  # All tasks preserved
+        # With 2 TP=1 lanes, rebalancing should split Heavy across both
+        assert heavy_lanes >= 2
+
+    def test_single_model_uses_replicas_not_tp(self):
+        """Single model (fits on 1 GPU) on 4 GPUs → 4 lanes with split tasks."""
+        s, _, _ = make_scheduler()
+        # No TP config → auto-TP would be 1 (model fits)
+        groups = [
+            ("Model", [make_task(f"t{i}", model="Model") for i in range(100)]),
+        ]
+        result = s._assign_groups_to_gpus(groups, 4)
+        # Should use multiple lanes (replicas), not TP
+        non_empty = [q for q in result if q]
+        assert len(non_empty) >= 2  # Split across lanes
+        total_tasks = sum(len(t) for q in result for _, t in q)
+        assert total_tasks == 100
+
+    def test_tp_config_default_is_one(self):
+        """Models without explicit TP config should default to tp=1."""
+        s, _, _ = make_scheduler()
+        s.set_tp_config({"BigModel": 4})
+        assert s._get_tp("BigModel") == 4
+        assert s._get_tp("UnknownModel") == 1
+
+    def test_auto_tp_small_model_single_gpu(self):
+        """Model that fits in one GPU should auto-compute TP=1."""
+        s, _, _ = make_scheduler()
+        # 14GB model on 24GB GPU (80% usable = 19.2GB) → fits
+        s._estimated_model_sizes["SmallModel"] = int(14e9)
+        s._gpu_mem_bytes = int(24e9)
+        assert s._get_tp("SmallModel") == 1
+
+    def test_auto_tp_large_model_needs_two(self):
+        """Model too large for one GPU should auto-compute TP=2."""
+        s, _, _ = make_scheduler()
+        # 30GB model on 24GB GPU (80% usable = 19.2GB) → needs 2 GPUs
+        s._estimated_model_sizes["LargeModel"] = int(30e9)
+        s._gpu_mem_bytes = int(24e9)
+        assert s._get_tp("LargeModel") == 2
+
+    def test_auto_tp_very_large_model_power_of_two(self):
+        """TP should always be a power of 2."""
+        s, _, _ = make_scheduler()
+        # 60GB model on 24GB GPU (80% usable = 19.2GB) → needs ceil(60/19.2)=4
+        s._estimated_model_sizes["HugeModel"] = int(60e9)
+        s._gpu_mem_bytes = int(24e9)
+        assert s._get_tp("HugeModel") == 4
+
+    def test_manual_tp_overrides_auto(self):
+        """Manual tp_config should override auto-computation."""
+        s, _, _ = make_scheduler()
+        s._estimated_model_sizes["Model"] = int(30e9)
+        s._gpu_mem_bytes = int(24e9)
+        # Auto would be TP=2, but manual sets TP=4
+        s.set_tp_config({"Model": 4})
+        assert s._get_tp("Model") == 4
+
+
+# ============================================================================ #
+# Memory-Aware Prefetch Guard
+# ============================================================================ #
+
+
+class TestMemoryAwarePrefetch:
+    """Verify _can_prefetch memory checks."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_pool_allows_prefetch(self):
+        s, _, _ = make_scheduler()
+        s.cpu_mem_pool_bytes = 0  # Unknown
+        assert await s._can_prefetch("any-model") is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_model_size_allows_prefetch(self):
+        s, _, _ = make_scheduler()
+        s.cpu_mem_pool_bytes = 100_000_000_000
+        # No entry in _estimated_model_sizes
+        assert await s._can_prefetch("unknown-model") is True
+
+    @pytest.mark.asyncio
+    async def test_fits_in_pool(self):
+        s, _, _ = make_scheduler()
+        s.cpu_mem_pool_bytes = 40_000_000_000  # 40GB
+        s._estimated_model_sizes = {"ModelA": 15_000_000_000}  # 15GB
+        s._cpu_cached_models = set()
+        assert await s._can_prefetch("ModelA") is True
+
+    @pytest.mark.asyncio
+    async def test_exceeds_pool(self):
+        s, _, _ = make_scheduler()
+        s.cpu_mem_pool_bytes = 20_000_000_000  # 20GB
+        s._estimated_model_sizes = {
+            "ModelA": 15_000_000_000,
+            "ModelB": 15_000_000_000,
+        }
+        s._cpu_cached_models = {"ModelA"}  # 15GB used
+        # ModelB needs 15GB, only 5GB free
+        assert await s._can_prefetch("ModelB") is False
+
+    @pytest.mark.asyncio
+    async def test_exact_fit(self):
+        s, _, _ = make_scheduler()
+        s.cpu_mem_pool_bytes = 30_000_000_000  # 30GB
+        s._estimated_model_sizes = {
+            "ModelA": 15_000_000_000,
+            "ModelB": 15_000_000_000,
+        }
+        s._cpu_cached_models = {"ModelA"}
+        # ModelB needs exactly the remaining 15GB
+        assert await s._can_prefetch("ModelB") is True
+
+
+# ============================================================================ #
+# Proactive Model Unloading
+# ============================================================================ #
+
+
+class TestProactiveUnloading:
+    """Verify _do_unload is called after model groups finish."""
+
+    @pytest.mark.asyncio
+    async def test_do_unload_calls_storage_manager(self):
+        s, _, _ = make_scheduler()
+        mock_sm = MagicMock()
+        mock_sm.unload_from_cpu = AsyncMock(return_value=True)
+        s.storage_manager = mock_sm
+        s._cpu_cached_models = {"ModelA"}
+
+        await s._do_unload("ModelA")
+
+        mock_sm.unload_from_cpu.assert_called_once_with("ModelA")
+        assert "ModelA" not in s._cpu_cached_models
+
+    @pytest.mark.asyncio
+    async def test_do_unload_no_storage_manager(self):
+        s, _, _ = make_scheduler()
+        s.storage_manager = None
+        # Should not raise
+        await s._do_unload("ModelA")
+
+    @pytest.mark.asyncio
+    async def test_do_unload_failure_keeps_cached(self):
+        s, _, _ = make_scheduler()
+        mock_sm = MagicMock()
+        mock_sm.unload_from_cpu = AsyncMock(side_effect=Exception("gRPC error"))
+        s.storage_manager = mock_sm
+        s._cpu_cached_models = {"ModelA"}
+
+        await s._do_unload("ModelA")
+        # Should still be in cached set since unload failed
+        assert "ModelA" in s._cpu_cached_models
+
+    @pytest.mark.asyncio
+    async def test_single_gpu_queue_unloads_after_group(self):
+        """_run_single_gpu_queue should unload each model after its last group."""
+        s, db, router = make_scheduler()
+        mock_sm = MagicMock()
+        mock_sm.unload_from_cpu = AsyncMock(return_value=True)
+        s.storage_manager = mock_sm
+
+        tasks_a = [make_task(f"a{i}", model="A") for i in range(3)]
+        tasks_b = [make_task(f"b{i}", model="B") for i in range(2)]
+        groups = [("A", tasks_a), ("B", tasks_b)]
+
+        await s._run_single_gpu_queue(groups, do_prefetch=False)
+
+        # Both models should have been unloaded
+        unload_calls = mock_sm.unload_from_cpu.call_args_list
+        unloaded_models = [c[0][0] for c in unload_calls]
+        assert "A" in unloaded_models
+        assert "B" in unloaded_models
+
+    @pytest.mark.asyncio
+    async def test_multi_gpu_queue_unloads_after_group(self):
+        """_process_gpu_queue should unload model after its last group on that GPU."""
+        s, db, router = make_scheduler()
+        mock_sm = MagicMock()
+        mock_sm.unload_from_cpu = AsyncMock(return_value=True)
+        s.storage_manager = mock_sm
+
+        tasks = [make_task(f"t{i}", model="A") for i in range(3)]
+        queue = [("A", tasks)]
+
+        await s._process_gpu_queue(
+            gpu_id=0,
+            queue=queue,
+            do_prefetch=False,
+            num_replicas_per_model={"A": 1},
+        )
+
+        mock_sm.unload_from_cpu.assert_called_once_with("A")
+
+
+# ============================================================================ #
+# Autoscaler Batch Registration
+# ============================================================================ #
+
+
+class TestAutoscalerBatchRegistration:
+    """Verify batches are registered/unregistered with autoscaler."""
+
+    @pytest.mark.asyncio
+    async def test_register_on_process_start(self):
+        s, db, router = make_scheduler()
+        mock_as = MagicMock()
+        mock_as.receive_metrics = MagicMock()
+        mock_as.register_active_batch = MagicMock()
+        mock_as.unregister_active_batch = MagicMock()
+        s.autoscaler = mock_as
+
+        tasks = [
+            make_task("t1", batch_id="b1", model="A"),
+            make_task("t2", batch_id="b1", model="B"),
+        ]
+        db.get_batch_tasks.side_effect = [
+            tasks,  # initial fetch
+            [make_task("t1", batch_id="b1", model="A", status="completed"),
+             make_task("t2", batch_id="b1", model="B", status="completed")],  # final check
+        ]
+
+        await s._process_batch("b1")
+
+        # Should register for both models
+        register_calls = mock_as.register_active_batch.call_args_list
+        registered = set(c[0][0] for c in register_calls)
+        assert "A:vllm" in registered
+        assert "B:vllm" in registered
+
+    @pytest.mark.asyncio
+    async def test_unregister_on_completion(self):
+        s, db, router = make_scheduler()
+        mock_as = MagicMock()
+        mock_as.receive_metrics = MagicMock()
+        mock_as.register_active_batch = MagicMock()
+        mock_as.unregister_active_batch = MagicMock()
+        s.autoscaler = mock_as
+
+        tasks = [make_task("t1", batch_id="b1", model="A")]
+        completed = [make_task("t1", batch_id="b1", model="A", status="completed")]
+        db.get_batch_tasks.side_effect = [tasks, completed]
+
+        await s._process_batch("b1")
+
+        # Should unregister
+        unregister_calls = mock_as.unregister_active_batch.call_args_list
+        assert any("A:vllm" in str(c) for c in unregister_calls)
+
+
+# ============================================================================ #
+# Strategy Execution
+# ============================================================================ #
+
+
+class TestStrategyExecution:
+    """Verify sync, chunked, and semaphore strategies all execute correctly."""
+
+    @pytest.mark.asyncio
+    async def test_sync_strategy(self):
+        s, db, router = make_scheduler()
+        s.set_strategy("sync")
+        tasks = [make_task(f"t{i}", model="A") for i in range(5)]
+        await s._execute_group(tasks)
+        assert router.handle_request.call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_chunked_strategy(self):
+        s, db, router = make_scheduler()
+        s.set_strategy("chunked")
+        tasks = [make_task(f"t{i}", model="A") for i in range(10)]
+        await s._execute_group(tasks)
+        assert router.handle_request.call_count == 10
+
+    @pytest.mark.asyncio
+    async def test_semaphore_strategy(self):
+        s, db, router = make_scheduler()
+        s.set_strategy("semaphore")
+        tasks = [make_task(f"t{i}", model="A") for i in range(10)]
+        await s._execute_group(tasks)
+        assert router.handle_request.call_count == 10
+
+    @pytest.mark.asyncio
+    async def test_invalid_strategy_raises(self):
+        s, _, _ = make_scheduler()
+        with pytest.raises(ValueError):
+            s.set_strategy("invalid_strategy")
+
+
+# ============================================================================ #
+# Prefetch with Threshold
+# ============================================================================ #
+
+
+class TestPrefetchWithThreshold:
+    """Verify prefetch triggers at the right threshold."""
+
+    @pytest.mark.asyncio
+    async def test_prefetch_triggers_at_threshold(self):
+        s, db, router = make_scheduler()
+        mock_sm = MagicMock()
+        mock_sm.prefetch_to_cpu = AsyncMock(return_value=True)
+        s.storage_manager = mock_sm
+        s.prefetch_threshold = 0.5
+
+        tasks = [make_task(f"t{i}", model="A") for i in range(10)]
+
+        await s._execute_group_with_prefetch(tasks, "B", 0.5)
+
+        # Prefetch should have been triggered for model B
+        mock_sm.prefetch_to_cpu.assert_called_once_with("B")
+
+    @pytest.mark.asyncio
+    async def test_prefetch_skipped_when_memory_full(self):
+        s, db, router = make_scheduler()
+        mock_sm = MagicMock()
+        mock_sm.prefetch_to_cpu = AsyncMock(return_value=True)
+        s.storage_manager = mock_sm
+        s.cpu_mem_pool_bytes = 10_000_000_000  # 10GB
+        s._estimated_model_sizes = {"A": 8_000_000_000, "B": 8_000_000_000}
+        s._cpu_cached_models = {"A"}  # 8GB used, only 2GB free
+
+        tasks = [make_task(f"t{i}", model="A") for i in range(10)]
+        await s._execute_group_with_prefetch(tasks, "B", 0.5)
+
+        # Prefetch should NOT have been called (B needs 8GB, only 2GB free)
+        mock_sm.prefetch_to_cpu.assert_not_called()
+
+
+# ============================================================================ #
+# End-to-End: Full Batch Processing
+# ============================================================================ #
+
+
+class TestEndToEndBatchProcessing:
+    """Integration tests for the full _process_batch path."""
+
+    @pytest.mark.asyncio
+    async def test_single_model_batch(self):
+        s, db, router = make_scheduler()
+        tasks = [make_task(f"t{i}", batch_id="b1", model="A") for i in range(5)]
+        completed = [make_task(f"t{i}", batch_id="b1", model="A", status="completed") for i in range(5)]
+        db.get_batch_tasks.side_effect = [tasks, completed]
+
+        await s._process_batch("b1")
+
+        assert router.handle_request.call_count == 5
+        db.update_batch_job_status.assert_any_call("b1", "in_progress")
+        db.update_batch_job_status.assert_any_call("b1", "completed")
+
+    @pytest.mark.asyncio
+    async def test_multi_model_batch(self):
+        s, db, router = make_scheduler()
+        tasks = [
+            *[make_task(f"a{i}", batch_id="b1", model="A") for i in range(3)],
+            *[make_task(f"b{i}", batch_id="b1", model="B") for i in range(2)],
+        ]
+        completed = [make_task(f"x{i}", batch_id="b1", model="A", status="completed") for i in range(5)]
+        db.get_batch_tasks.side_effect = [tasks, completed]
+
+        await s._process_batch("b1")
+
+        assert router.handle_request.call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_empty_batch_skipped(self):
+        s, db, router = make_scheduler()
+        db.get_batch_tasks.return_value = []
+
+        await s._process_batch("b1")
+
+        assert router.handle_request.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_all_completed_batch_marked_done(self):
+        s, db, router = make_scheduler()
+        tasks = [make_task("t1", batch_id="b1", model="A", status="completed")]
+        db.get_batch_tasks.return_value = tasks
+
+        await s._process_batch("b1")
+
+        db.update_batch_job_status.assert_called_with("b1", "completed")
+
+    @pytest.mark.asyncio
+    async def test_task_failure_recorded(self):
+        s, db, router = make_scheduler()
+        router.handle_request = AsyncMock(side_effect=Exception("inference error"))
+
+        tasks = [make_task("t1", batch_id="b1", model="A")]
+        completed = [make_task("t1", batch_id="b1", model="A", status="failed")]
+        db.get_batch_tasks.side_effect = [tasks, completed]
+
+        await s._process_batch("b1")
+
+        # Task should be recorded as failed
+        upsert_calls = db.upsert_batch_task.call_args_list
+        assert any(c.kwargs.get("status") == "failed" or
+                    (len(c.args) > 6 and c.args[6] == "failed")
+                    for c in upsert_calls)
+
+
+# ============================================================================ #
+# GPU Allocation Reclamation
+# ============================================================================ #
+
+
+class TestGPUAllocationReclamation:
+    """Verify _prepare_gpu_allocations frees GPUs before multi-GPU batch."""
+
+    def _make_deployment(self, model_name, backend="vllm", max_replicas=2):
+        dep = MagicMock()
+        dep.id = f"{model_name}:{backend}"
+        dep.model_name = model_name
+        dep.backend = backend
+        dep.status = "active"
+        dep.max_replicas = max_replicas
+        dep.desired_replicas = max_replicas
+        return dep
+
+    @pytest.mark.asyncio
+    async def test_scales_down_unneeded_deployment(self):
+        """Deployments not in the batch should be scaled to 0."""
+        s, db, router = make_scheduler()
+        mock_as = MagicMock()
+        mock_as._active_batches = {"OldModel:vllm": {"old_batch"}}
+        mock_as.unregister_active_batch = MagicMock()
+        s.autoscaler = mock_as
+
+        # OldModel has 2 endpoints but is NOT needed for this batch
+        old_dep = self._make_deployment("OldModel")
+        db.get_all_deployments.return_value = [old_dep]
+        db.get_deployment_endpoints.return_value = ["ep1", "ep2"]
+        db.update_max_replicas = MagicMock()
+        db.update_desired_replicas = MagicMock()
+
+        # No pylet → skip wait loop
+        s.pylet_client = None
+
+        await s._prepare_gpu_allocations(
+            batch_id="b1",
+            num_replicas_per_model={"NewModel": 1},
+            num_gpus=2,
+        )
+
+        db.update_max_replicas.assert_called_once_with("OldModel:vllm", 0)
+        db.update_desired_replicas.assert_called_once_with("OldModel:vllm", 0)
+        mock_as.unregister_active_batch.assert_called_once_with("OldModel:vllm", "old_batch")
+
+    @pytest.mark.asyncio
+    async def test_scales_down_over_provisioned_deployment(self):
+        """Batch model with too many replicas should be capped."""
+        s, db, router = make_scheduler()
+        mock_as = MagicMock()
+        mock_as._active_batches = {"A:vllm": {"baseline_batch"}}
+        mock_as.unregister_active_batch = MagicMock()
+        s.autoscaler = mock_as
+
+        dep_a = self._make_deployment("A", max_replicas=2)
+        db.get_all_deployments.return_value = [dep_a]
+        db.get_deployment_endpoints.return_value = ["ep1", "ep2"]  # 2 endpoints
+        db.update_max_replicas = MagicMock()
+        db.update_desired_replicas = MagicMock()
+
+        s.pylet_client = None
+
+        await s._prepare_gpu_allocations(
+            batch_id="b1",
+            num_replicas_per_model={"A": 1, "B": 1},  # A needs only 1
+            num_gpus=2,
+        )
+
+        db.update_max_replicas.assert_called_once_with("A:vllm", 1)
+        db.update_desired_replicas.assert_called_once_with("A:vllm", 1)
+        # Should unregister stale batch but NOT current batch
+        mock_as.unregister_active_batch.assert_called_once_with("A:vllm", "baseline_batch")
+
+    @pytest.mark.asyncio
+    async def test_no_action_when_already_correct(self):
+        """No scaling needed if deployments match batch requirements."""
+        s, db, router = make_scheduler()
+
+        dep_a = self._make_deployment("A", max_replicas=1)
+        db.get_all_deployments.return_value = [dep_a]
+        db.get_deployment_endpoints.return_value = ["ep1"]  # 1 endpoint = 1 needed
+        db.update_max_replicas = MagicMock()
+        db.update_desired_replicas = MagicMock()
+
+        s.pylet_client = None
+
+        await s._prepare_gpu_allocations(
+            batch_id="b1",
+            num_replicas_per_model={"A": 1},
+            num_gpus=1,
+        )
+
+        db.update_max_replicas.assert_not_called()
+        db.update_desired_replicas.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_waits_for_gpus_with_pylet(self):
+        """Should poll pylet until enough GPUs are free."""
+        s, db, router = make_scheduler()
+
+        dep = self._make_deployment("OldModel")
+        db.get_all_deployments.return_value = [dep]
+        db.get_deployment_endpoints.return_value = ["ep1"]
+        db.update_max_replicas = MagicMock()
+        db.update_desired_replicas = MagicMock()
+
+        # Simulate pylet returning 0 free GPUs, then 2
+        mock_pylet = MagicMock()
+        worker_busy = MagicMock()
+        worker_busy.available_gpus = 0
+        worker_free = MagicMock()
+        worker_free.available_gpus = 2
+        mock_pylet.get_online_workers = AsyncMock(
+            side_effect=[
+                [worker_busy],
+                [worker_busy],
+                [worker_free],  # 3rd poll: GPUs freed
+            ]
+        )
+        s.pylet_client = mock_pylet
+
+        await s._prepare_gpu_allocations(
+            batch_id="b1",
+            num_replicas_per_model={"NewModel": 1},
+            num_gpus=2,
+        )
+
+        assert mock_pylet.get_online_workers.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_clears_models_ready_cache(self):
+        """Scaling down should clear _models_ready so endpoints are re-verified."""
+        s, db, router = make_scheduler()
+        s._models_ready = {"OldModel", "SomeOther"}
+
+        dep = self._make_deployment("OldModel")
+        db.get_all_deployments.return_value = [dep]
+        db.get_deployment_endpoints.return_value = ["ep1"]
+        db.update_max_replicas = MagicMock()
+        db.update_desired_replicas = MagicMock()
+
+        s.pylet_client = None
+
+        await s._prepare_gpu_allocations(
+            batch_id="b1",
+            num_replicas_per_model={"NewModel": 1},
+            num_gpus=2,
+        )
+
+        assert len(s._models_ready) == 0

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -47,8 +47,8 @@ class TestRouterConfig:
 
         config = RouterConfig()
 
-        assert config.max_buffer_size == 10
-        assert config.cold_start_timeout == 120.0
+        assert config.max_buffer_size == 100
+        assert config.cold_start_timeout == 180.0
         assert config.request_timeout == 300.0
 
     def test_custom_config(self):
@@ -86,8 +86,8 @@ class TestRouterInitialization:
 
         router = Router(database=database, autoscaler=mock_autoscaler)
 
-        assert router.config.max_buffer_size == 10
-        assert router.config.cold_start_timeout == 120.0
+        assert router.config.max_buffer_size == 100
+        assert router.config.cold_start_timeout == 180.0
 
     def test_init_custom_config(self, database, mock_autoscaler):
         """Test Router with custom config."""


### PR DESCRIPTION
## Summary

Adds a **Batch Scheduler** component sitting between the API gateway and the router. Accepts OpenAI-style batch payloads at `/v1/batches`, auto-manages per-model deployments for the duration of the batch, and dispatches tasks across them.

Demo-stage PR — ergonomics and polish are not the focus.

## Features

- `/v1/batches` endpoint — submit / poll / fetch results for multi-task batches; tasks in a single batch can target different models.
- **Auto-deployment** — models referenced in a batch are deployed on demand (scale-to-zero friendly) and allowed to scale down after completion.
- **Auto tensor-parallelism** — picks the smallest power-of-2 TP that fits ~80 % of per-GPU memory, using live `nvidia-smi` readings.
- **Model grouping** — sorts tasks by model to minimise cold-start thrashing when a batch mixes multiple models.
- **Checkpoint prefetch** hook into sllm-store so weights land in pinned memory during queue wait (no conflict with `cudaHostRegister`).
- **Chat-template kwargs passthrough** (e.g. `enable_thinking: false`) so Qwen3/thinking models can be driven to emit direct answers.

## Build / deps

- Consolidate CUDA 12.8 torch stack (`torch 2.9.1` + `torchvision 0.24.1` + `torchaudio 2.9.1` + `nvidia-nccl-cu12 2.27.5`), `transformers>=4.55`, and sllm_store build deps (`cmake`/`ninja`/`numpy`) into `requirements.txt` so a fresh `pip install -r` works end-to-end.
- `setup.py` filters blanks/comments/pip-flag lines in `fetch_requirements` so setuptools accepts the new `--index-url` entries.
- README gets a short *"Different Hardware / CUDA Version?"* section pointing at the two things to retarget (wheel index, arch list).

## Scripts / tests

- `scripts/start_cluster_batch.sh` — convenience bring-up with `ENABLE_BATCH_SCHEDULER=true` and an 80 GB pinned memory pool sized for Qwen3-32B.
- `tests/unit/test_batch_scheduler.py` — ~900 lines covering scheduler strategies, deployment lifecycle, and the auto-TP path.

## Test plan

- [ ] `pytest tests/unit/test_batch_scheduler.py`
- [ ] End-to-end: `bash scripts/start_cluster_batch.sh`, submit a mixed-model batch via `curl -X POST http://localhost:8343/v1/batches -d @batch.json`, verify auto-TP picks the correct value and all tasks complete.
- [ ] Fresh install from this branch picks up the new consolidated `requirements.txt` without extra pip commands.